### PR TITLE
N-02: add getters for request data

### DIFF
--- a/contracts/token/ConfidentialFungibleToken.sol
+++ b/contracts/token/ConfidentialFungibleToken.sol
@@ -248,6 +248,11 @@ abstract contract ConfidentialFungibleToken is IConfidentialFungibleToken {
         _requestHandles[requestId] = euint64.wrap(0);
     }
 
+    /// @dev Returns the cypher-text handle associated with a given request Id `requestId`.
+    function requestHandles(uint256 requestId) public view virtual returns (euint64) {
+        return _requestHandles[requestId];
+    }
+
     function _setOperator(address holder, address operator, uint48 until) internal virtual {
         _operators[holder][operator] = until;
         emit OperatorSet(holder, operator, until);

--- a/contracts/token/extensions/ConfidentialFungibleTokenERC20Wrapper.sol
+++ b/contracts/token/extensions/ConfidentialFungibleTokenERC20Wrapper.sol
@@ -134,6 +134,11 @@ abstract contract ConfidentialFungibleTokenERC20Wrapper is ConfidentialFungibleT
         SafeERC20.safeTransfer(underlying(), to, amount * rate());
     }
 
+    /// @dev Returns the receiver address associated with a given request Id `requestId`.
+    function receivers(uint256 requestId) public view virtual returns (address) {
+        return _receivers[requestId];
+    }
+
     function _unwrap(address from, address to, euint64 amount) internal virtual {
         require(to != address(0), ConfidentialFungibleTokenInvalidReceiver(to));
         require(


### PR DESCRIPTION
Unsure if we will implement this. The data associated with requests is only stored until the request is fulfilled and is wholly intended for internal accounting.