### PR TITLE
Remove ERC1363 mentions for confidential callbacks

### DIFF
--- a/contracts/token/ConfidentialFungibleToken.sol
+++ b/contracts/token/ConfidentialFungibleToken.sol
@@ -21,7 +21,7 @@ import { TFHESafeMath } from "../utils/TFHESafeMath.sol";
  * - All balances are encrypted
  * - Transfers happen without revealing amounts
  * - Support for operators (delegated transfer capabilities with time bounds)
- * - ERC1363-like functionality with transfer-and-call pattern
+ * - Transfer and call pattern
  * - Safe overflow/underflow handling for FHE operations
  */
 abstract contract ConfidentialFungibleToken is IConfidentialFungibleToken {
@@ -277,7 +277,7 @@ abstract contract ConfidentialFungibleToken is IConfidentialFungibleToken {
 
         // Perform callback
         transferred = TFHE.select(
-            ConfidentialFungibleTokenUtils.checkOnERC1363TransferReceived(msg.sender, from, to, sent, data),
+            ConfidentialFungibleTokenUtils.checkOnTransferReceived(msg.sender, from, to, sent, data),
             sent,
             TFHE.asEuint64(0)
         );

--- a/contracts/token/utils/ConfidentialFungibleTokenUtils.sol
+++ b/contracts/token/utils/ConfidentialFungibleTokenUtils.sol
@@ -9,7 +9,7 @@ import { ConfidentialFungibleToken } from "../ConfidentialFungibleToken.sol";
 /// @dev Library that provides common {ConfidentialFungibleToken} utility functions.
 library ConfidentialFungibleTokenUtils {
     /**
-     * @dev Performs an `ERC1363` like transfer callback to the recipient of the transfer `to`. Should be invoked
+     * @dev Performs a transfer callback to the recipient of the transfer `to`. Should be invoked
      * after all transfers "withCallback" on a {ConfidentialFungibleToken}.
      *
      * The transfer callback is not invoked on the recipient if the recipient has no code (i.e. is an EOA). If the
@@ -17,7 +17,7 @@ library ConfidentialFungibleTokenUtils {
      * {IConfidentialFungibleTokenReceiver-onConfidentialTransferReceived} and return an `ebool` indicating
      * whether the transfer was accepted or not. If the `ebool` is `false`, the transfer will be reversed.
      */
-    function checkOnERC1363TransferReceived(
+    function checkOnTransferReceived(
         address operator,
         address from,
         address to,


### PR DESCRIPTION
We are not reverting on tranfer with callbacks made to EOAs. Since this is non-standard for ERC1363, we will remove mentions of the ERC.