### PR TITLE
Fix docs embed reference

### DIFF
--- a/contracts/mocks/docs/ERC7984MintableBurnable.sol
+++ b/contracts/mocks/docs/ERC7984MintableBurnable.sol
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {FHE, externalEuint64, ebool, euint64} from "@fhevm/solidity/lib/FHE.sol";
+import {FHE, externalEuint64} from "@fhevm/solidity/lib/FHE.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ERC7984} from "../../token/ERC7984/ERC7984.sol";
 
 contract ERC7984MintableBurnable is ERC7984, Ownable {
-    using FHE for *;
-
     constructor(
         address owner,
         string memory name,
@@ -16,10 +14,10 @@ contract ERC7984MintableBurnable is ERC7984, Ownable {
     ) ERC7984(name, symbol, uri) Ownable(owner) {}
 
     function mint(address to, externalEuint64 amount, bytes memory inputProof) public onlyOwner {
-        _mint(to, amount.fromExternal(inputProof));
+        _mint(to, FHE.fromExternal(amount, inputProof));
     }
 
     function burn(address from, externalEuint64 amount, bytes memory inputProof) public onlyOwner {
-        _burn(from, amount.fromExternal(inputProof));
+        _burn(from, FHE.fromExternal(amount, inputProof));
     }
 }

--- a/contracts/mocks/docs/SwapERC7984ToERC20.sol
+++ b/contracts/mocks/docs/SwapERC7984ToERC20.sol
@@ -4,12 +4,9 @@ pragma solidity ^0.8.24;
 import {FHE, externalEuint64, euint64} from "@fhevm/solidity/lib/FHE.sol";
 import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-
 import {IERC7984} from "../../interfaces/IERC7984.sol";
 
 contract SwapConfidentialToERC20 {
-    using FHE for *;
-
     error SwapConfidentialToERC20InvalidGatewayRequest(uint256 requestId);
 
     mapping(uint256 requestId => address) private _receivers;
@@ -22,8 +19,8 @@ contract SwapConfidentialToERC20 {
     }
 
     function swapConfidentialToERC20(externalEuint64 encryptedInput, bytes memory inputProof) public {
-        euint64 amount = encryptedInput.fromExternal(inputProof);
-        amount.allowTransient(address(_fromToken));
+        euint64 amount = FHE.fromExternal(encryptedInput, inputProof);
+        FHE.allowTransient(amount, address(_fromToken));
         euint64 amountTransferred = _fromToken.confidentialTransferFrom(msg.sender, address(this), amount);
 
         bytes32[] memory cts = new bytes32[](1);

--- a/docs/modules/ROOT/pages/token.adoc
+++ b/docs/modules/ROOT/pages/token.adoc
@@ -97,6 +97,6 @@ Swapping from a confidential token to a non-confidential token is the most compl
 
 [source,solidity]
 ----
-include::api:example$SwapConfidentialToERC20.sol[]
+include::api:example$SwapERC7984ToERC20.sol[]
 ----
 

--- a/docs/modules/ROOT/pages/token.adoc
+++ b/docs/modules/ROOT/pages/token.adoc
@@ -80,7 +80,7 @@ Swapping from a confidential `ERC7984` to another confidential `ERC7984` is a bi
 
 [source,solidity]
 ----
-include::api:example$SwapERC7984ToERC7984.sol[lines=8..24]
+include::api:example$SwapERC7984ToERC7984.sol[lines=8..23]
 ----
 
 The steps are as follows:


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Fix incorrect AsciiDoc include path in token.adoc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed token swap examples to reference the ERC7984→ERC20 flow and adjusted the included snippet range so examples render correctly.
* **Refactor**
  * Internal contract examples updated to use a simplified encryption API for handling confidential amounts, improving clarity and consistency without changing public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->