### PR TITLE
Set minimum node version to `20.19.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "elliptic": "6.6.1"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.19.0"
   },
   "lint-staged": {
     "*.{js,ts}": [


### PR DESCRIPTION
Testing doesn't run with earlier versions of node installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the minimum required Node.js version to 20.19 or higher. This ensures compatibility with the latest runtime expectations and leverages recent stability and security improvements. If you run the project locally, you may need to upgrade your Node.js installation before installing dependencies or starting the app. No feature behavior changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->