### PR TITLE
Update `checkOnTransferReceived` doc

### DIFF
--- a/contracts/token/ERC7984/utils/ERC7984Utils.sol
+++ b/contracts/token/ERC7984/utils/ERC7984Utils.sol
@@ -16,7 +16,8 @@ library ERC7984Utils {
      * The transfer callback is not invoked on the recipient if the recipient has no code (i.e. is an EOA). If the
      * recipient has non-zero code, it must implement
      * {IERC7984Receiver-onConfidentialTransferReceived} and return an `ebool` indicating
-     * whether the transfer was accepted or not. If the `ebool` is `false`, the transfer will be reversed.
+     * whether the transfer was accepted or not. If the `ebool` is `false`, the transfer function
+     * should try to refund the `from` address.
      */
     function checkOnTransferReceived(
         address operator,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation clarifying fallback behavior when a receiver contract returns false. The transfer function will now attempt to refund the initiating address instead of reversing the transfer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->