### PR TITLE
N-04: remove unused import in `ERC7984Rwa`

### DIFF
--- a/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
@@ -10,7 +10,6 @@ import {Multicall} from "@openzeppelin/contracts/utils/Multicall.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {IERC7984} from "./../../../interfaces/IERC7984.sol";
 import {IERC7984Rwa} from "./../../../interfaces/IERC7984Rwa.sol";
-import {FHESafeMath} from "./../../../utils/FHESafeMath.sol";
 import {ERC7984} from "./../ERC7984.sol";
 import {ERC7984Freezable} from "./ERC7984Freezable.sol";
 import {ERC7984Restricted} from "./ERC7984Restricted.sol";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused import from the token contract extension to maintain code cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->