### PR TITLE
Fix release tag commit generated by CI

### DIFF
--- a/scripts/release/workflow/github-release.js
+++ b/scripts/release/workflow/github-release.js
@@ -9,7 +9,7 @@ module.exports = async ({ github, context }) => {
     owner: context.repo.owner,
     repo: context.repo.repo,
     tag_name: `v${version}`,
-    target_commitish: github.ref_name,
+    target_commitish: context.sha,
     body: extractSection(changelog, version),
     prerelease: process.env.PRERELEASE === 'true',
   });


### PR DESCRIPTION
Currently, release tags don't get assigned the correct commit. This is because `github.ref_name` is empty when `github-release.js` is executed. Switching to use `context.sha` fixes this.

Fixes #261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to use an alternative commit reference for release targeting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->