### PR TITLE
Remove mention of freezer role from `ERC7984Freezable` docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - `ERC7984Omnibus`: Add an extension of `ERC7984` that exposes new functions for transferring between confidential subaccounts on omnibus wallets. ([#186](https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/pull/186))
 - `ERC7984ObserverAccess`: Add an extension for ERC7984, which allows each account to add an observer who is given access to their transfer and balance amounts. ([#148](https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/pull/148))
 - `ERC7984Restricted`: An extension of `ERC7984` that implements user account transfer restrictions. ([#182](https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/pull/182))
-- `ERC7984Freezable`: Add an extension to `ERC7984`, which allows accounts granted the "freezer" role to freeze and unfreeze tokens. ([#151](https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/pull/151))
+- `ERC7984Freezable`: Add an extension to `ERC7984` that implements internal functions with the ability to freeze/unfreeze user tokens. ([#151](https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/pull/151))
 - `ERC7984Rwa`: An extension of `ERC7984`, that supports confidential Real World Assets (RWAs). ([#160](https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/pull/160))
 
 ### Utils

--- a/contracts/token/ERC7984/extensions/ERC7984Freezable.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Freezable.sol
@@ -9,11 +9,10 @@ import {ERC7984} from "../ERC7984.sol";
 
 /**
  * @dev Extension of {ERC7984} that implements a confidential
- * freezing mechanism that can be managed by an authorized account with
- * {setConfidentialFrozen} functions.
+ * freezing mechanism that can be managed by calling the internal function
+ * {_setConfidentialFrozen} by an inheriting contract.
  *
- * The freezing mechanism provides the guarantee to the contract owner
- * (e.g. a DAO or a well-configured multisig) that a specific confidential
+ * The freezing mechanism provides the guarantee that a specific confidential
  * amount of tokens held by an account won't be transferable until those
  * tokens are unfrozen.
  *


### PR DESCRIPTION
The freezer role was removed during the last release cycle, but some of the docs accompanying it remained--this PR removed docs mentioning the freezer role.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified token freezing mechanism documentation to reflect internal implementation approach and updated associated guarantees.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->