### PR TITLE
Add missing contracts to API docs

### DIFF
--- a/contracts/interfaces/README.adoc
+++ b/contracts/interfaces/README.adoc
@@ -7,7 +7,9 @@ These interfaces are available as `.sol` files and are useful to interact with t
 
 - {IERC7984}
 - {IERC7984Receiver}
+- {IERC7984Rwa}
 
 == Core
 {{IERC7984}}
 {{IERC7984Receiver}}
+{{IERC7984Rwa}}

--- a/contracts/token/README.adoc
+++ b/contracts/token/README.adoc
@@ -12,6 +12,7 @@ This set of interfaces, contracts, and utilities are all related to `ERC7984`, a
 - {ERC7984Restricted}: An extension of {ERC7984} that implements user account transfer restrictions.
 - {ERC7984Omnibus}: An extension of {ERC7984} that emits additional events for omnibus transfers, which contain encrypted addresses for the sub-account sender and recipient.
 - {ERC7984Rwa}: Extension of {ERC7984} that supports confidential Real World Assets (RWAs) by providing compliance checks, transfer controls and enforcement actions.
+- {ERC7984Votes}: An extension of {ERC7984} that supports confidential vote tracking and delegation via {VotesConfidential}.
 - {ERC7984Utils}: A library that provides the on-transfer callback check used by {ERC7984}.
 
 == Core
@@ -24,6 +25,7 @@ This set of interfaces, contracts, and utilities are all related to `ERC7984`, a
 {{ERC7984Restricted}}
 {{ERC7984Omnibus}}
 {{ERC7984Rwa}}
+{{ERC7984Votes}}
 
 == Utilities
 {{ERC7984Utils}}


### PR DESCRIPTION
`IERC7984Rwa` and `ERC7984Votes` were missing from the docs API reference. This PR adds them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated interface reference documentation to include new RWA interface support
  * Added documentation for ERC7984Votes extension with voting functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->