### PR TITLE
Remove released changesets

### DIFF
--- a/.changeset/gentle-horses-repeat.md
+++ b/.changeset/gentle-horses-repeat.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-confidential-contracts': minor
----
-
-`ERC7984`: Support ERC-165 interface detection on ERC-7984.

--- a/.changeset/puny-nails-bathe.md
+++ b/.changeset/puny-nails-bathe.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-confidential-contracts': minor
----
-
-Migrate FHEVM contracts from v0.8 to v0.9

--- a/.changeset/stale-symbols-rule.md
+++ b/.changeset/stale-symbols-rule.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-confidential-contracts': minor
----
-
-`IERC7984`: Support ERC-165 interface detection on ERC-7984.

--- a/.changeset/wet-breads-study.md
+++ b/.changeset/wet-breads-study.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-confidential-contracts': minor
----
-
-`FHESafeMath`: Return initialized 0 value instead of unititialized `euint64` on `tryDecrease` with initialized `delta` and unitiialized `oldValue`.


### PR DESCRIPTION
Some changesets added during the release process were not automatically removed. This PR removes them, as they are no longer necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed outdated changeset entries to streamline release tracking and documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->