### PR TITLE
Use NPM trusted publisher auth

### DIFF
--- a/.github/workflows/release-cycle.yml
+++ b/.github/workflows/release-cycle.yml
@@ -162,10 +162,8 @@ jobs:
       - name: Publish
         run: bash scripts/release/workflow/publish.sh
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           TARBALL: ${{ steps.pack.outputs.tarball }}
           TAG: ${{ steps.pack.outputs.tag }}
-          NPM_CONFIG_PROVENANCE: true
       - name: Create Github Release
         uses: actions/github-script@v7
         env:


### PR DESCRIPTION
Use NPM trusted publisher link for publishing auth instead of a token. No longer need token or explicit provenance params.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified package publishing workflow configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->