### PR TITLE
Fix `msg.sig` comments in `ERC7984Rwa`

### DIFF
--- a/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
@@ -242,7 +242,7 @@ abstract contract ERC7984Rwa is IERC7984Rwa, ERC7984Freezable, ERC7984Restricted
     /// @dev Private function which checks if the called function is a {forceConfidentialTransferFrom}.
     function _isForceTransfer() private pure returns (bool) {
         return
-            msg.sig == 0x6c9c3c85 || // bytes4(keccak256("forceConfidentialTransferFrom(address,address,bytes32)"))
-            msg.sig == 0x44fd6e40; // bytes4(keccak256("forceConfidentialTransferFrom(address,address,bytes32,bytes)"))
+            msg.sig == 0x6c9c3c85 || // bytes4(keccak256("forceConfidentialTransferFrom(address,address,bytes32,bytes)"))
+            msg.sig == 0x44fd6e40; // bytes4(keccak256("forceConfidentialTransferFrom(address,address,bytes32)"))
     }
 }


### PR DESCRIPTION
The previous comments were swapped. This corrects the comment ordering to correctly align with the hash values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified inline comments to accurately map function signatures to their corresponding overloads for improved code readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->