### PR TITLE
Rename `ERC7984ERC20Wrapper` `totalSupply()` to `inferredTotalSuppy()`

### DIFF
--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -158,7 +158,7 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC1363Receiver {
      * Reductions will lag compared to {confidentialTotalSupply} since it is updated on {unwrap} while this function updates
      * on {finalizeUnwrap}.
      */
-    function totalSupply() public view virtual returns (uint256) {
+    function inferredTotalSupply() public view virtual returns (uint256) {
         return underlying().balanceOf(address(this)) / rate();
     }
 
@@ -175,7 +175,7 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC1363Receiver {
      * not overflow.
      */
     function _checkConfidentialTotalSupply() internal virtual {
-        if (totalSupply() > maxTotalSupply()) {
+        if (inferredTotalSupply() > maxTotalSupply()) {
             revert ERC7984TotalSupplyOverflow();
         }
     }


### PR DESCRIPTION
Rename the `totalSupply()` function to `inferredTotalSupply()` to avoid accidental misuse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the token supply query function name in the ERC7984 wrapper contract to better reflect its calculation methodology based on underlying token balance and exchange rate.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->