### PR TITLE
Rename Wrapper test to `ERC7984ERC20Wrapper.test.ts`

### DIFF
--- a/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
@@ -10,7 +10,7 @@ const symbol = 'CFT';
 const uri = 'https://example.com/metadata';
 
 /* eslint-disable no-unexpected-multiline */
-describe('ERC7984Wrapper', function () {
+describe('ERC7984ERC20Wrapper', function () {
   beforeEach(async function () {
     const accounts = await ethers.getSigners();
     const [holder, recipient, operator] = accounts;


### PR DESCRIPTION
The test for the `ERC7984ERC20Wrapper` contract was not named to match the contract file. This PR changes it to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite naming for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->