### PR TITLE
Fix typo in `ERC7984Votes`

### DIFF
--- a/contracts/token/ERC7984/extensions/ERC7984Votes.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Votes.sol
@@ -10,7 +10,7 @@ import {ERC7984} from "./../ERC7984.sol";
  * @dev Extension of {ERC7984} supporting confidential votes tracking and delegation.
  *
  * The amount of confidential voting units an account has is equal to the balance of
- * that account. Voing power is taken into account when an account delegates votes to itself or to another
+ * that account. Voting power is taken into account when an account delegates votes to itself or to another
  * account.
  */
 abstract contract ERC7984Votes is ERC7984, VotesConfidential {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the ERC7984Votes extension comment, changing “Voing power” to “Voting power.”
  * No functional or behavioral changes were made.
  * Interfaces, workflows, and on-chain behavior remain unchanged.
  * This update improves clarity for readers of the documentation without impacting contracts, deployments, or integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->