### PR TITLE
Return the amount of wrapped token sent on wrap calls

### DIFF
--- a/.changeset/pink-areas-double.md
+++ b/.changeset/pink-areas-double.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': minor
+---
+
+`ERC7984ERC20Wrapper`: return the amount of wrapped token sent on wrap calls.

--- a/contracts/interfaces/IERC7984ERC20Wrapper.sol
+++ b/contracts/interfaces/IERC7984ERC20Wrapper.sol
@@ -7,8 +7,12 @@ import {IERC7984} from "./IERC7984.sol";
 
 /// @dev Interface for ERC7984ERC20Wrapper contract.
 interface IERC7984ERC20Wrapper is IERC7984 {
-    /// @dev Wraps `amount` of the underlying token into a confidential token and sends it to `to`.
-    function wrap(address to, uint256 amount) external;
+    /**
+     * @dev Wraps `amount` of the underlying token into a confidential token and sends it to `to`.
+     *
+     * Returns amount of wrapped token sent.
+     */
+    function wrap(address to, uint256 amount) external returns (euint64);
 
     /**
      * @dev Unwraps tokens from `from` and sends the underlying tokens to `to`. The caller must be `from`

--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -79,13 +79,18 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
      * @dev See {IERC7984ERC20Wrapper-wrap}. Tokens are exchanged at a fixed rate specified by {rate} such that
      * `amount / rate()` confidential tokens are sent. The amount transferred in is rounded down to the nearest
      * multiple of {rate}.
+     *
+     * Returns the amount of wrapped token sent.
      */
-    function wrap(address to, uint256 amount) public virtual override {
+    function wrap(address to, uint256 amount) public virtual override returns (euint64) {
         // take ownership of the tokens
         SafeERC20.safeTransferFrom(IERC20(underlying()), msg.sender, address(this), amount - (amount % rate()));
 
         // mint confidential token
-        _mint(to, FHE.asEuint64(SafeCast.toUint64(amount / rate())));
+        euint64 wrappedAmountSent = _mint(to, FHE.asEuint64(SafeCast.toUint64(amount / rate())));
+        FHE.allowTransient(wrappedAmountSent, msg.sender);
+
+        return wrappedAmountSent;
     }
 
     /// @dev Unwrap without passing an input proof. See {unwrap-address-address-bytes32-bytes} for more details.


### PR DESCRIPTION
The amount wrapped is readily available to the wrap function--we should return it with transient approval for integrators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The wrap function now returns the amount of wrapped tokens sent on wrap calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->