### PR TITLE
Use dashes when referring to ERC-7984 in docs

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -2,7 +2,7 @@
 
 A library of smart contracts that use ciphertext for amount, allowing for a wide variety of confidential use-cases, such as confidential tokens, auctions, vesting, voting etc. While the contracts are not written in an opinionated method (other than using the standard encrypted values published by Zama), for testing and examples in the documentation, the https://github.com/zama-ai/fhevm-solidity[Zama fhEVM] will be used to operate on and decrypt https://www.zama.ai/introduction-to-homomorphic-encryption[FHE] ciphertext.
 
-NOTE: All contracts must set their respective co-processor configuration during construction (or initialization). This can be done automatically by inheriting contracts in https://github.com/zama-ai/fhevm/blob/v0.7.12/library-solidity/config/ZamaConfig.sol#L47-L73[`ZamaConfig`].
+NOTE: All contracts must set their respective co-processor configuration during construction (or initialization). This can be done automatically by inheriting https://github.com/zama-ai/fhevm/blob/e446c370002f62f193bbb5eb4075dea5d29a6996/library-solidity/config/ZamaConfig.sol#L96-L104[`ZamaEthereumConfig`].
 
 [[security]]
 == Security

--- a/docs/modules/ROOT/pages/token.adoc
+++ b/docs/modules/ROOT/pages/token.adoc
@@ -1,6 +1,6 @@
-= ERC7984
+= ERC-7984
 
-xref:api:token.adoc#ERC7984[`ERC7984`] is a standard fungible token implementation that is similar to ERC-20, but built from the ground up with confidentiality in mind. All balance and transfer amounts are represented as ciphertext handles, ensuring that no data is leaked to the public. 
+xref:api:token.adoc#ERC7984[ERC-7984] is a standard fungible token implementation that is similar to ERC-20, but built from the ground up with confidentiality in mind. All balance and transfer amounts are represented as ciphertext handles, ensuring that no data is leaked to the public. 
 
 While the standard is built with inspiration from ERC-20, it is not ERC-20 compliant--the standard takes learning from all tokens built over the past 10 years (ERC-20, ERC-721, ERC-1155, ERC-6909 etc) and provides an interface for maximal functionality.
 
@@ -57,9 +57,9 @@ include::api:example$ERC7984MintableBurnable.sol[]
 
 Swapping is one of the most primitive use-cases for fungible tokens. Below are examples for swapping between confidential and non-confidential tokens.
 
-==== Swap `ERC20` to `ERC7984`
+==== Swap ERC-20 to ERC-7984
 
-Swapping from a non-confidential `ERC20` to a confidential `ERC7984` is simple and actually done within the `ERC7984ERC20Wrapper`. See the excerpt from the `wrap` function below.
+Swapping from a non-confidential ERC-20 to a confidential ERC-7984 is simple and actually done within the `ERC7984ERC20Wrapper`. See the excerpt from the `wrap` function below.
 
 [source,solidity]
 ----
@@ -72,11 +72,11 @@ function wrap(address to, uint256 amount) public virtual {
 }
 ----
 
-The `ERC20` token is simply transferred in, which would revert on failure. We then transfer out the correct amount of the `ERC7984` using the internal `_mint` function, which is guaranteed to succeed.
+The `ERC20` token is simply transferred in, which would revert on failure. We then transfer out the correct amount of the ERC-7984 using the internal `_mint` function, which is guaranteed to succeed.
 
-==== Swap `ERC7984` to `ERC7984`
+==== Swap ERC-7984 to ERC-7984
 
-Swapping from a confidential `ERC7984` to another confidential `ERC7984` is a bit more complex although quite simple given the usage of the `FHE` library. For the sake of the example, we will swap from `fromToken` to `toToken` with a 1:1 exchange rate.
+Swapping from a confidential ERC-7984 to another confidential ERC-7984 is a bit more complex although quite simple given the usage of the `FHE` library. For the sake of the example, we will swap from `fromToken` to `toToken` with a 1:1 exchange rate.
 
 [source,solidity]
 ----
@@ -91,7 +91,7 @@ The steps are as follows:
 . Allow the `toToken` to access `amountTransferred`
 . Transfer `amountTransferred` to `msg.sender`
 
-==== Swap `ERC7984` to `ERC20`
+==== Swap ERC-7984 to ERC-20
 
 Swapping from a confidential token to a non-confidential token is the most complex since the decrypted data must be accessed to accurately complete the request. Decryption in our example will be done off-chain and relayed back using Zama's Gateway. Below is an example of a contract doing a 1:1 swap from a confidential token to an ERC20 token.
 


### PR DESCRIPTION
When referring to ERCs outside of code, we use dashes as is the convention.