### PR TITLE
Allow claiming on behalf of another account in batcher

### DIFF
--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -84,7 +84,7 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
     error BatchNonexistent(uint256 batchId);
 
     /// @dev The `account` has a zero deposits in batch `batchId`.
-    error ZeroClaimableBalance(uint256 batchId, address account);
+    error ZeroDeposits(uint256 batchId, address account);
 
     /**
      * @dev The batch `batchId` is in the state `current`, which is invalid for the operation.
@@ -147,6 +147,8 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
         _validateStateBitmap(batchId, _encodeStateBitmap(BatchState.Pending) | _encodeStateBitmap(BatchState.Canceled));
 
         euint64 deposit = deposits(batchId, msg.sender);
+        require(FHE.isInitialized(deposit), ZeroDeposits(batchId, msg.sender));
+
         euint64 totalDeposits_ = totalDeposits(batchId);
 
         FHE.allowTransient(deposit, address(fromToken()));
@@ -330,7 +332,7 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
         _validateStateBitmap(batchId, _encodeStateBitmap(BatchState.Finalized));
 
         euint64 deposit = deposits(batchId, account);
-        require(FHE.isInitialized(deposit), ZeroClaimableBalance(batchId, account));
+        require(FHE.isInitialized(deposit), ZeroDeposits(batchId, account));
 
         // Overflow is not possible on mul since `type(uint64).max ** 2 < type(uint128).max`.
         // Given that the output of the entire batch must fit in uint64, individual user outputs must also fit.

--- a/test/finance/BatcherConfidential.test.ts
+++ b/test/finance/BatcherConfidential.test.ts
@@ -297,7 +297,7 @@ describe('BatcherConfidential', function () {
 
     it('should revert if account did not participate in the batch', async function () {
       await expect(this.batcher.claim(this.batchId, this.recipient))
-        .to.be.revertedWithCustomError(this.batcher, 'ZeroClaimableBalance')
+        .to.be.revertedWithCustomError(this.batcher, 'ZeroDeposits')
         .withArgs(this.batchId, this.recipient.address);
     });
 
@@ -462,6 +462,12 @@ describe('BatcherConfidential', function () {
       await expect(this.batcher.quit(this.batchId))
         .to.be.revertedWithCustomError(this.batcher, 'BatchUnexpectedState')
         .withArgs(this.batchId, BatchState.Dispatched, encodeStateBitmap(BatchState.Pending, BatchState.Canceled));
+    });
+
+    it('should revert if caller did not participate in the batch', async function () {
+      await expect(this.batcher.connect(this.recipient).quit(this.batchId))
+        .to.be.revertedWithCustomError(this.batcher, 'ZeroDeposits')
+        .withArgs(this.batchId, this.recipient.address);
     });
 
     it('should emit event', async function () {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claim function now supports claiming on behalf of a specified account, enabling delegated claim operations
  * Added support for relayer-initiated claims, allowing third parties to process claims on behalf of depositors

* **Tests**
  * Updated and expanded test coverage to validate new account delegation and relayer claim functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->