### PR TITLE
Return a bytes32 unwrap id from the `_unwrap` function in `BatcherConfidential`

### DIFF
--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -219,7 +219,7 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
 
         assert(unwrapRequester(euint64.unwrap(unwrapAmount_)) == address(0));
 
-        // WARNING: Storing unwrap requests in a mapping from cipher-text to address assumes that
+        // WARNING: Directly using the cipher-text as the unwrap request id assumes that
         // cipher-texts are unique--this holds here but is not always true. Be cautious when assuming
         // cipher-text uniqueness.
         bytes32 unwrapRequestId = euint64.unwrap(unwrapAmount_);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Refactor**
- Unwrap function now returns the unwrap request ID directly as bytes32 instead of an encrypted amount, streamlining the operation by removing an extra decryption step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->