### PR TITLE
Don't call `super._update` from `_forceUpdate`

### DIFF
--- a/.changeset/fruity-jeans-scream.md
+++ b/.changeset/fruity-jeans-scream.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': patch
+---
+
+`ERC7984Rwa`: Always call `_update` on transfers (even force). Bypass restriction via restriction override.

--- a/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
@@ -217,23 +217,30 @@ abstract contract ERC7984Rwa is IERC7984Rwa, ERC7984Freezable, ERC7984Restricted
         return super._update(from, to, encryptedAmount);
     }
 
-    /// @dev Internal function which forces transfer of confidential amount of tokens from account to account by skipping compliance checks.
+    /**
+     * @dev Internal function which forces transfer of confidential amount of tokens from account to account.
+     * Some checks are bypassed by detecting the transaction selector.
+     */
     function _forceUpdate(address from, address to, euint64 encryptedAmount) internal virtual returns (euint64) {
-        // bypassing `from` restriction check with {_checkSenderRestriction}. Still performing `to` restriction check.
-        // bypassing paused state by directly calling `super._update`
-        euint64 transferred = super._update(from, to, encryptedAmount);
+        euint64 transferred = _update(from, to, encryptedAmount);
         FHE.allow(transferred, msg.sender);
         return transferred;
     }
 
-    /**
-     * @dev Bypasses the `from` restriction check when performing a {forceConfidentialTransferFrom}.
-     */
-    function _checkSenderRestriction(address account) internal view override {
+    /// @dev Bypasses {ERC7984Restricted} `from` restriction check when performing a {forceConfidentialTransferFrom}.
+    function _checkSenderRestriction(address account) internal view virtual override {
         if (_isForceTransfer()) {
             return;
         }
         super._checkSenderRestriction(account);
+    }
+
+    /// @dev Bypasses {Pausable} check when performing a {forceConfidentialTransferFrom}.
+    function _requireNotPaused() internal view virtual override {
+        if (_isForceTransfer()) {
+            return;
+        }
+        super._requireNotPaused();
     }
 
     /// @dev Private function which checks if the called function is a {forceConfidentialTransferFrom}.

--- a/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
@@ -222,7 +222,7 @@ abstract contract ERC7984Rwa is IERC7984Rwa, ERC7984Freezable, ERC7984Restricted
     }
 
     /// @dev Bypasses {ERC7984Restricted} `from` restriction check when performing a {forceConfidentialTransferFrom}.
-    function _checkSenderRestriction(address account) internal view virtual override {
+    function _checkSenderRestriction(address account) internal view override {
         if (_isForceTransfer(msg.sig)) {
             return;
         }

--- a/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
@@ -223,24 +223,24 @@ abstract contract ERC7984Rwa is IERC7984Rwa, ERC7984Freezable, ERC7984Restricted
 
     /// @dev Bypasses {ERC7984Restricted} `from` restriction check when performing a {forceConfidentialTransferFrom}.
     function _checkSenderRestriction(address account) internal view virtual override {
-        if (_isForceTransfer()) {
+        if (_isForceTransfer(msg.sig)) {
             return;
         }
         super._checkSenderRestriction(account);
     }
 
     /// @dev Bypasses {Pausable} check when performing a {forceConfidentialTransferFrom}.
-    function _requireNotPaused() internal view virtual override {
-        if (_isForceTransfer()) {
+    function _requireNotPaused() internal view override {
+        if (_isForceTransfer(msg.sig)) {
             return;
         }
         super._requireNotPaused();
     }
 
-    /// @dev Private function which checks if the called function is a {forceConfidentialTransferFrom}.
-    function _isForceTransfer() private pure returns (bool) {
+    /// @dev Private function which checks if the function selector indicates a force transfer.
+    function _isForceTransfer(bytes4 selector) private pure returns (bool) {
         return
-            msg.sig == 0x6c9c3c85 || // bytes4(keccak256("forceConfidentialTransferFrom(address,address,bytes32,bytes)"))
-            msg.sig == 0x44fd6e40; // bytes4(keccak256("forceConfidentialTransferFrom(address,address,bytes32)"))
+            selector == 0x6c9c3c85 || // bytes4(keccak256("forceConfidentialTransferFrom(address,address,bytes32,bytes)"))
+            selector == 0x44fd6e40; // bytes4(keccak256("forceConfidentialTransferFrom(address,address,bytes32)"))
     }
 }

--- a/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
@@ -163,7 +163,9 @@ abstract contract ERC7984Rwa is IERC7984Rwa, ERC7984Freezable, ERC7984Restricted
         externalEuint64 encryptedAmount,
         bytes calldata inputProof
     ) public virtual onlyAgent returns (euint64) {
-        return _forceUpdate(from, to, FHE.fromExternal(encryptedAmount, inputProof));
+        euint64 transferred = _transfer(from, to, FHE.fromExternal(encryptedAmount, inputProof));
+        FHE.allow(transferred, msg.sender);
+        return transferred;
     }
 
     /**
@@ -175,12 +177,14 @@ abstract contract ERC7984Rwa is IERC7984Rwa, ERC7984Freezable, ERC7984Restricted
         address from,
         address to,
         euint64 encryptedAmount
-    ) public virtual onlyAgent returns (euint64 transferred) {
+    ) public virtual onlyAgent returns (euint64) {
         require(
             FHE.isAllowed(encryptedAmount, msg.sender),
             ERC7984UnauthorizedUseOfEncryptedAmount(encryptedAmount, msg.sender)
         );
-        return _forceUpdate(from, to, encryptedAmount);
+        euint64 transferred = _transfer(from, to, encryptedAmount);
+        FHE.allow(transferred, msg.sender);
+        return transferred;
     }
 
     /// @inheritdoc ERC7984Freezable
@@ -215,16 +219,6 @@ abstract contract ERC7984Rwa is IERC7984Rwa, ERC7984Freezable, ERC7984Restricted
     ) internal virtual override(ERC7984Freezable, ERC7984Restricted) whenNotPaused returns (euint64) {
         // frozen and restriction checks performed through inheritance
         return super._update(from, to, encryptedAmount);
-    }
-
-    /**
-     * @dev Internal function which forces transfer of confidential amount of tokens from account to account.
-     * Some checks are bypassed by detecting the transaction selector.
-     */
-    function _forceUpdate(address from, address to, euint64 encryptedAmount) internal virtual returns (euint64) {
-        euint64 transferred = _update(from, to, encryptedAmount);
-        FHE.allow(transferred, msg.sender);
-        return transferred;
     }
 
     /// @dev Bypasses {ERC7984Restricted} `from` restriction check when performing a {forceConfidentialTransferFrom}.


### PR DESCRIPTION
Bypassing `_update` via `super._update` is not a valid flow. We should never be calling super for a virtual function. Other extensions may also override this function, and linearization may result in them being more abstracted than `ERC7984Rwa`. The current flow would fully bypass their execution unintentionally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved the internal architecture of force transfer compliance handling. The mechanism now more consistently manages pause states and sender restriction bypasses through an enhanced detection approach. This restructuring ensures more reliable and predictable behavior when force transfers interact with compliance checks, strengthening the overall robustness and maintainability of the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->