### PR TITLE
Clarify token callback refund flow in docs

### DIFF
--- a/contracts/token/ERC7984/ERC7984.sol
+++ b/contracts/token/ERC7984/ERC7984.sol
@@ -258,8 +258,10 @@ abstract contract ERC7984 is IERC7984, ERC165 {
      * The token contract initiates a second transfer refunding the tokens from the recipient to the sender--the amount is 0 if the callback succeeds,
      * otherwise the amount is the amount that was transferred.
      *
-     * WARNING: The second transfer is subject to the same flow as the first transfer and may fail for a variety of reasons (such as insufficient balance).
-     * In this case, the tokens do not return to the sender.
+     * WARNING: The refund triggered when {IERC7984Receiver-onConfidentialTransferReceived} returns an encrypted
+     * false is best-effort only. A receiver that transfers, burns, or otherwise reduces its balance during
+     * the hook can still return false, in which case the refund transfers zero tokens. The sender's tokens
+     * end up with the recipient rather than being refunded.
      */
     function _transferAndCall(
         address from,

--- a/contracts/token/ERC7984/ERC7984.sol
+++ b/contracts/token/ERC7984/ERC7984.sol
@@ -252,6 +252,15 @@ abstract contract ERC7984 is IERC7984, ERC165 {
         return _update(from, to, amount);
     }
 
+    /**
+     * @dev Transfers the given amount of tokens from `from` to `to` and calls the `onConfidentialTransferReceived` function on the recipient.
+     *
+     * The token contract initiates a second transfer refunding the tokens from the recipient to the sender--the amount is 0 if the callback succeeds,
+     * otherwise the amount is the amount that was transferred.
+     *
+     * WARNING: The second transfer is subject to the same flow as the first transfer and may fail for a variety of reasons (such as insufficient balance).
+     * In this case, the tokens do not return to the sender.
+     */
     function _transferAndCall(
         address from,
         address to,

--- a/docs/modules/ROOT/pages/token.adoc
+++ b/docs/modules/ROOT/pages/token.adoc
@@ -39,7 +39,7 @@ WARNING: Setting an operator for any amount of time allows the operator to _**ta
 
 The token standard exposes transfer functions with and without callbacks. It is up to the caller to decide if a callback is necessary for the transfer. For smart contracts that support it, callbacks allow the operator approval step to be skipped and directly invoke the receiver contract via a callback.
 
-Smart contracts that are the target of a callback must implement xref:api:interfaces.adoc#IERC7984Receiver[`++IERC7984Receiver++`]. After balances are updated for a transfer, the callback is triggered by calling the xref:api:interfaces.adoc#IERC7984Receiver-onConfidentialTransferReceived-address-address-euint64-bytes-[`++onConfidentialTransferReceived++`] function. The function must either revert or return an `ebool` indicating success. If the callback returns false, the token transfer is reversed.
+Smart contracts that are the target of a callback must implement xref:api:interfaces.adoc#IERC7984Receiver[`++IERC7984Receiver++`]. After balances are updated for a transfer, the callback is triggered by calling the xref:api:interfaces.adoc#IERC7984Receiver-onConfidentialTransferReceived-address-address-euint64-bytes-[`++onConfidentialTransferReceived++`] function. The function must either revert or return an `ebool` indicating success. If the callback returns false, the ERC-7984 token contract attempts to refund the tokens from the recipient to the sender.
 
 [[examples]]
 == Examples


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced ERC-7984 token documentation with detailed callback behavior specifications
  * Clarified callback failure semantics and token refund mechanisms for transfer operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->