### PR TITLE
Ensure batcher wrapper underlying tokens are distinct

### DIFF
--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -110,6 +110,9 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
     /// @dev The given `token` does not support `IERC7984ERC20Wrapper` via `ERC165`.
     error InvalidWrapperToken(address token);
 
+    /// @dev The underlying wrapper tokens are the same.
+    error DuplicateUnderlyingTokens();
+
     constructor(IERC7984ERC20Wrapper fromToken_, IERC7984ERC20Wrapper toToken_) {
         require(
             ERC165Checker.supportsInterface(address(fromToken_), type(IERC7984ERC20Wrapper).interfaceId),
@@ -119,6 +122,7 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
             ERC165Checker.supportsInterface(address(toToken_), type(IERC7984ERC20Wrapper).interfaceId),
             InvalidWrapperToken(address(toToken_))
         );
+        require(address(fromToken_.underlying()) != address(toToken_.underlying()), DuplicateUnderlyingTokens());
 
         _fromToken = fromToken_;
         _toToken = toToken_;

--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -122,7 +122,7 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
             ERC165Checker.supportsInterface(address(toToken_), type(IERC7984ERC20Wrapper).interfaceId),
             InvalidWrapperToken(address(toToken_))
         );
-        require(address(fromToken_.underlying()) != address(toToken_.underlying()), DuplicateUnderlyingTokens());
+        require(fromToken_.underlying() != toToken_.underlying(), DuplicateUnderlyingTokens());
 
         _fromToken = fromToken_;
         _toToken = toToken_;

--- a/test/finance/BatcherConfidential.test.ts
+++ b/test/finance/BatcherConfidential.test.ts
@@ -105,6 +105,24 @@ describe('BatcherConfidential', function () {
     });
   });
 
+  it('should reject different wrappers with the same underlying', async function () {
+    const anotherWrapper = await ethers.deployContract('$ERC7984ERC20WrapperMock', [
+      this.fromTokenUnderlying,
+      name,
+      symbol,
+      uri,
+    ]);
+
+    await expect(
+      ethers.deployContract('$BatcherConfidentialSwapMock', [
+        this.fromToken,
+        anotherWrapper,
+        this.exchange,
+        this.operator,
+      ]),
+    ).to.be.revertedWithCustomError(this.batcher, 'DuplicateUnderlyingTokens');
+  });
+
   it('should reject invalid fromToken', async function () {
     const confidentialToken = await ethers.deployContract('$ERC7984Mock', ['Mock Token', 'MTK', 'URI']);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced batcher with configuration validation to prevent deployment when multiple token wrapper contracts resolve to the same underlying asset, eliminating misconfiguration risks and ensuring valid token pair configurations.

* **Tests**
  * Added test case to verify batcher deployment correctly rejects configurations where different wrapper contracts wrap the same underlying token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->