### PR TITLE
Use `saturatingSub` in `ERC7984Freezable`

### DIFF
--- a/contracts/token/ERC7984/extensions/ERC7984Freezable.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Freezable.sol
@@ -40,11 +40,7 @@ abstract contract ERC7984Freezable is ERC7984 {
 
     /// @dev Internal function to calculate the available balance of an account. Does not give any allowances.
     function _confidentialAvailable(address account) internal virtual returns (euint64) {
-        (ebool success, euint64 unfrozen) = FHESafeMath.tryDecrease(
-            confidentialBalanceOf(account),
-            confidentialFrozen(account)
-        );
-        return FHE.select(success, unfrozen, FHE.asEuint64(0));
+        return FHESafeMath.saturatingSub(confidentialBalanceOf(account), confidentialFrozen(account));
     }
 
     /// @dev Internal function to freeze a confidential amount of tokens for an account.


### PR DESCRIPTION
The saturating math functions were recently added. Using in `ERC7984Freezable` simplifies code and saves gas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the calculation of available token amounts using a more efficient and safer subtraction method that prevents mathematical underflow conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/openzeppelin-confidential-contracts/pull/365)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->