### PR TITLE
Bypass recipient restriction on RWA force transfer

### DIFF
--- a/.changeset/chilly-beers-type.md
+++ b/.changeset/chilly-beers-type.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': minor
+---
+
+`ERC7984Rwa`: Bypass recipient on RWA force transfer in addition to sender.

--- a/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
@@ -265,7 +265,7 @@ abstract contract ERC7984Rwa is IERC7984Rwa, ERC7984Freezable, ERC7984Restricted
         super._checkSenderRestriction(account);
     }
 
-    /// @dev Bypasses {ERC7984Restricted} `to` restriction check when performing a forced transfer.
+    /// @dev Bypasses {ERC7984Restricted} `to` restriction check when performing a forced transfer or token recovery.
     function _checkRecipientRestriction(address account) internal view override {
         if (_isForceTransfer(msg.sig)) {
             return;

--- a/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
@@ -257,12 +257,20 @@ abstract contract ERC7984Rwa is IERC7984Rwa, ERC7984Freezable, ERC7984Restricted
         return super._update(from, to, encryptedAmount);
     }
 
-    /// @dev Bypasses {ERC7984Restricted} `from` restriction check when performing a {forceConfidentialTransferFrom}.
+    /// @dev Bypasses {ERC7984Restricted} `from` restriction check when performing a forced transfer.
     function _checkSenderRestriction(address account) internal view override {
         if (_isForceTransfer(msg.sig)) {
             return;
         }
         super._checkSenderRestriction(account);
+    }
+
+    /// @dev Bypasses {ERC7984Restricted} `to` restriction check when performing a forced transfer.
+    function _checkRecipientRestriction(address account) internal view override {
+        if (_isForceTransfer(msg.sig)) {
+            return;
+        }
+        super._checkRecipientRestriction(account);
     }
 
     /// @dev Bypasses {Pausable} check when performing a {forceConfidentialTransferFrom}.

--- a/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
@@ -257,7 +257,7 @@ abstract contract ERC7984Rwa is IERC7984Rwa, ERC7984Freezable, ERC7984Restricted
         return super._update(from, to, encryptedAmount);
     }
 
-    /// @dev Bypasses {ERC7984Restricted} `from` restriction check when performing a forced transfer.
+    /// @dev Bypasses {ERC7984Restricted} `from` restriction check when performing a forced transfer or token recovery.
     function _checkSenderRestriction(address account) internal view override {
         if (_isForceTransfer(msg.sig)) {
             return;

--- a/test/token/ERC7984/extensions/ERC7984Rwa.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984Rwa.test.ts
@@ -526,7 +526,7 @@ describe('ERC7984Rwa', function () {
     });
 
     for (const withProof of [true, false]) {
-      it(`should not force transfer if receiver blocked ${withProof ? 'with proof' : ''}`, async function () {
+      it(`should force transfer if receiver blocked ${withProof ? 'with proof' : ''}`, async function () {
         const { token, agent1, recipient, anyone } = await fixture();
         let params = [recipient.address, anyone.address] as unknown as [
           from: AddressLike,
@@ -546,17 +546,13 @@ describe('ERC7984Rwa', function () {
           params.push(await token.connect(agent1).createEncryptedAmount.staticCall(amount));
         }
         await token.connect(agent1).blockUser(anyone);
-        await expect(
-          token
-            .connect(agent1)
-            [
-              withProof
-                ? 'forceConfidentialTransferFrom(address,address,bytes32,bytes)'
-                : 'forceConfidentialTransferFrom(address,address,bytes32)'
-            ](...params),
-        )
-          .to.be.revertedWithCustomError(token, 'UserRestricted')
-          .withArgs(anyone.address);
+        await token
+          .connect(agent1)
+          [
+            withProof
+              ? 'forceConfidentialTransferFrom(address,address,bytes32,bytes)'
+              : 'forceConfidentialTransferFrom(address,address,bytes32)'
+          ](...params);
       });
     }
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Forced transfers now execute successfully even when recipients are restricted, while sender restrictions remain enforced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/openzeppelin-confidential-contracts/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->