### PR TITLE
Test uninitialized input in saturating sub

### DIFF
--- a/test/utils/FHESafeMath.test.ts
+++ b/test/utils/FHESafeMath.test.ts
@@ -180,6 +180,10 @@ describe('FHESafeMath', function () {
 
   const saturatingSubArgsOptions: [BigNumberish | undefined, BigNumberish | undefined, BigNumberish | undefined][] = [
     // a - b = c (saturating at 0)
+    [undefined, undefined, 0],
+    [undefined, 0, 0],
+    [0, undefined, 0],
+    [1, undefined, 1],
     [0, 0, 0],
     [1, 1, 0],
     [5, 3, 2],
@@ -204,7 +208,7 @@ describe('FHESafeMath', function () {
       operation: '-',
     },
   ]) {
-    describe(`saturating ${params.functionSignature.startsWith('saturatingAdd') ? 'add' : 'sub'}`, function () {
+    describe.only(`saturating ${params.functionSignature.startsWith('saturatingAdd') ? 'add' : 'sub'}`, function () {
       for (const args of params.argsOptions) {
         it(`${args[0]} ${params.operation} ${args[1]} = ${args[2]}`, async function () {
           const [a, b, c] = args;

--- a/test/utils/FHESafeMath.test.ts
+++ b/test/utils/FHESafeMath.test.ts
@@ -208,7 +208,7 @@ describe('FHESafeMath', function () {
       operation: '-',
     },
   ]) {
-    describe.only(`saturating ${params.functionSignature.startsWith('saturatingAdd') ? 'add' : 'sub'}`, function () {
+    describe(`saturating ${params.functionSignature.startsWith('saturatingAdd') ? 'add' : 'sub'}`, function () {
       for (const args of params.argsOptions) {
         it(`${args[0]} ${params.operation} ${args[1]} = ${args[2]}`, async function () {
           const [a, b, c] = args;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Enhanced test coverage for safe subtraction operations with additional edge cases involving undefined inputs to verify saturation behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/openzeppelin-confidential-contracts/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->