### PR TITLE
Fix preTransfer returning a true ebool without calling super (#369)

### DIFF
--- a/contracts/token/ERC7984/utils/ERC7984BalanceCapHookModule.sol
+++ b/contracts/token/ERC7984/utils/ERC7984BalanceCapHookModule.sol
@@ -55,22 +55,23 @@ contract ERC7984BalanceCapHookModule is ERC7984HookModule {
         address from,
         address to,
         euint64 encryptedAmount
-    ) internal override returns (ebool) {
-        ebool compliant;
-        if (to == address(0) || from == to || !FHE.isInitialized(maxBalance(token))) {
-            compliant = FHE.asEbool(true);
-        } else {
+    ) internal override returns (ebool result) {
+        // super call
+        result = super._preTransfer(token, from, to, encryptedAmount);
+
+        // in non trivial cases, check (and document) compliance.
+        if (to != address(0) && to != from && FHE.isInitialized(maxBalance(token))) {
             euint64 balance = IERC7984Rwa(token).confidentialBalanceOf(to);
             _accessHandle(token, balance);
 
             // Note, if the balance would result in an overflow, transfer will fail due to total supply overflow.
             (, euint64 futureBalance) = FHESafeMath.tryIncrease(balance, encryptedAmount);
-            compliant = FHE.le(futureBalance, maxBalance(token));
+            ebool compliant = FHE.le(futureBalance, maxBalance(token));
+            _emitPreTransferResults(token, from, to, encryptedAmount, compliant, bytes32(0));
+
+            // integrate this module compliance result into the super result.
+            result = FHE.and(result, compliant);
         }
-
-        _emitPreTransferResults(token, from, to, encryptedAmount, compliant, bytes32(0));
-
-        return FHE.and(compliant, super._preTransfer(token, from, to, encryptedAmount));
     }
 
     /**

--- a/contracts/token/ERC7984/utils/ERC7984HolderCapHookModule.sol
+++ b/contracts/token/ERC7984/utils/ERC7984HolderCapHookModule.sol
@@ -63,31 +63,32 @@ contract ERC7984HolderCapHookModule is ERC7984HookModule {
         address from,
         address to,
         euint64 encryptedAmount
-    ) internal override returns (ebool) {
-        if (to == address(0) || to == from) {
-            return FHE.asEbool(true);
+    ) internal override returns (ebool result) {
+        result = super._preTransfer(token, from, to, encryptedAmount);
+
+        // in non trivial cases, check compliance.
+        if (to != address(0) && to != from) {
+            euint64 fromBalance = IERC7984Rwa(token).confidentialBalanceOf(from);
+            euint64 toBalance = IERC7984Rwa(token).confidentialBalanceOf(to);
+
+            _accessHandle(token, fromBalance);
+            _accessHandle(token, toBalance);
+
+            euint64 encryptedZero = FHE.asEuint64(0);
+
+            // note, if from is address(0):
+            // - fromBalance is an encrypted zero
+            // - from will be (erroneously) removed from the holder count only encryptedAmount is a zero
+            // that is fine because if encryptedAmount is a zero, then this value is dropped anyway.
+            euint64 adjustedHolderCount = FHE.add(
+                FHE.sub(holderCount(token), FHE.asEuint64(FHE.eq(fromBalance, encryptedAmount))),
+                FHE.asEuint64(FHE.and(FHE.eq(toBalance, encryptedZero), FHE.ne(encryptedAmount, encryptedZero)))
+            );
+            ebool compliant = FHE.le(adjustedHolderCount, maxHolderCount(token));
+
+            // integrate this module compliance result into the super result.
+            result = FHE.and(result, compliant);
         }
-
-        euint64 fromBalance = IERC7984Rwa(token).confidentialBalanceOf(from);
-        euint64 toBalance = IERC7984Rwa(token).confidentialBalanceOf(to);
-
-        _accessHandle(token, fromBalance);
-        _accessHandle(token, toBalance);
-
-        euint64 encryptedZero = FHE.asEuint64(0);
-
-        // note, if from is address(0):
-        // - fromBalance is an encrypted zero
-        // - from will be (erroneously) removed from the holder count only encryptedAmount is a zero
-        // that is fine because if encryptedAmount is a zero, then this value is dropped anyway.
-        euint64 adjustedHolderCount = FHE.add(
-            FHE.sub(holderCount(token), FHE.asEuint64(FHE.eq(fromBalance, encryptedAmount))),
-            FHE.asEuint64(FHE.and(FHE.eq(toBalance, encryptedZero), FHE.ne(encryptedAmount, encryptedZero)))
-        );
-
-        ebool compliant = FHE.le(adjustedHolderCount, maxHolderCount(token));
-
-        return FHE.and(compliant, super._preTransfer(token, from, to, encryptedAmount));
     }
 
     /// @inheritdoc ERC7984HookModule


### PR DESCRIPTION
Cherry pick from release-v0.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transfer validation logic in ERC7984 tokens to ensure balance cap and holder cap compliance checks are performed consistently and accurately during all transfer operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/openzeppelin-confidential-contracts/pull/378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->