### PR TITLE
Remove uninstall hook from `ERC7984Hooked`

### DIFF
--- a/contracts/interfaces/IERC7984HookModule.sol
+++ b/contracts/interfaces/IERC7984HookModule.sol
@@ -28,11 +28,4 @@ interface IERC7984HookModule is IERC165 {
 
     /// @dev Performs operations after installation.
     function onInstall(bytes calldata initData) external;
-
-    /**
-     * @dev Performs operations after uninstallation.
-     *
-     * NOTE: The module uninstallation will succeed even if this function reverts.
-     */
-    function onUninstall(bytes calldata deinitData) external;
 }

--- a/contracts/mocks/token/ERC7984/utils/ERC7984HookModuleMock.sol
+++ b/contracts/mocks/token/ERC7984/utils/ERC7984HookModuleMock.sol
@@ -9,34 +9,19 @@ import {ERC7984HookModule} from "../../../../token/ERC7984/utils/ERC7984HookModu
 
 contract ERC7984HookModuleMock is ERC7984HookModule, ZamaEthereumConfig {
     bool public isCompliant = true;
-    bool public revertOnUninstall = false;
 
     event PostTransfer();
     event PreTransfer();
 
     event OnInstall(bytes initData);
-    event OnUninstall(bytes deinitData);
 
     function onInstall(bytes calldata initData) public override {
         emit OnInstall(initData);
         super.onInstall(initData);
     }
 
-    function onUninstall(bytes calldata deinitData) public override {
-        if (revertOnUninstall) {
-            revert("Revert on uninstall");
-        }
-
-        emit OnUninstall(deinitData);
-        super.onUninstall(deinitData);
-    }
-
     function setIsCompliant(bool isCompliant_) public {
         isCompliant = isCompliant_;
-    }
-
-    function setRevertOnUninstall(bool revertOnUninstall_) public {
-        revertOnUninstall = revertOnUninstall_;
     }
 
     function _preTransfer(address token, address from, address, euint64) internal override returns (ebool) {

--- a/contracts/token/ERC7984/extensions/ERC7984Hooked.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Hooked.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.27;
 
 import {FHE, ebool, euint64} from "@fhevm/solidity/lib/FHE.sol";
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
-import {LowLevelCall} from "@openzeppelin/contracts/utils/LowLevelCall.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {IERC7984HookModule} from "./../../../interfaces/IERC7984HookModule.sol";
 import {HandleAccessManager} from "./../../../utils/HandleAccessManager.sol";
@@ -61,8 +60,8 @@ abstract contract ERC7984Hooked is ERC7984, HandleAccessManager {
     }
 
     /// @dev Uninstalls a hook module.
-    function uninstallModule(address module, bytes memory deinitData) public virtual onlyAuthorizedModuleChange {
-        _uninstallModule(module, deinitData);
+    function uninstallModule(address module) public virtual onlyAuthorizedModuleChange {
+        _uninstallModule(module);
     }
 
     /**
@@ -97,10 +96,8 @@ abstract contract ERC7984Hooked is ERC7984, HandleAccessManager {
     }
 
     /// @dev Internal function which uninstalls a module.
-    function _uninstallModule(address module, bytes memory deinitData) internal virtual {
+    function _uninstallModule(address module) internal virtual {
         require(_modules.remove(module), ERC7984HookedNonexistentModule(module));
-
-        LowLevelCall.callNoReturn(module, abi.encodeCall(IERC7984HookModule.onUninstall, (deinitData)));
 
         emit ERC7984HookedModuleUninstalled(module);
     }

--- a/contracts/token/ERC7984/utils/ERC7984BalanceCapHookModule.sol
+++ b/contracts/token/ERC7984/utils/ERC7984BalanceCapHookModule.sol
@@ -83,10 +83,4 @@ contract ERC7984BalanceCapHookModule is ERC7984HookModule {
         (externalEuint64 maxBalance_, bytes memory inputProof) = abi.decode(initData, (externalEuint64, bytes));
         _setMaxBalance(token, FHE.fromExternal(maxBalance_, inputProof));
     }
-
-    /// @inheritdoc ERC7984HookModule
-    function _onUninstall(address token, bytes calldata deinitData) internal virtual override {
-        super._onUninstall(token, deinitData);
-        _maxBalances[token] = euint64.wrap(0);
-    }
 }

--- a/contracts/token/ERC7984/utils/ERC7984HolderCapHookModule.sol
+++ b/contracts/token/ERC7984/utils/ERC7984HolderCapHookModule.sol
@@ -136,10 +136,4 @@ contract ERC7984HolderCapHookModule is ERC7984HookModule {
         uint64 maxHolderCount_ = abi.decode(initData, (uint64));
         _setMaxHolderCount(token, maxHolderCount_);
     }
-
-    function _onUninstall(address token, bytes calldata deinitData) internal virtual override {
-        super._onUninstall(token, deinitData);
-        delete _maxHolderCounts[token];
-        _holderCounts[token] = euint64.wrap(0);
-    }
 }

--- a/contracts/token/ERC7984/utils/ERC7984HolderCapHookModule.sol
+++ b/contracts/token/ERC7984/utils/ERC7984HolderCapHookModule.sol
@@ -130,6 +130,7 @@ contract ERC7984HolderCapHookModule is ERC7984HookModule {
             !FHE.isInitialized(IERC7984Rwa(token).confidentialTotalSupply()),
             ERC7984HolderCapHookModuleTotalSupplyInitialized()
         );
+        _holderCounts[token] = euint64.wrap(0);
 
         super._onInstall(token, initData);
 

--- a/contracts/token/ERC7984/utils/ERC7984HookModule.sol
+++ b/contracts/token/ERC7984/utils/ERC7984HookModule.sol
@@ -49,7 +49,7 @@ abstract contract ERC7984HookModule is IERC7984HookModule, ERC165 {
 
     /**
      * @dev Internal function which may be overridden by the derived contract to perform actions
-     * when the module is installed.
+     * when the module is installed. Should clean up dirty state from possible previous installations.
      */
     function _onInstall(address /* token */, bytes calldata /* initData */) internal virtual {}
 

--- a/contracts/token/ERC7984/utils/ERC7984HookModule.sol
+++ b/contracts/token/ERC7984/utils/ERC7984HookModule.sol
@@ -17,14 +17,6 @@ abstract contract ERC7984HookModule is IERC7984HookModule, ERC165 {
     /// @dev The caller `user` does not have access to the encrypted amount `amount`.
     error ERC7984HookModuleUnauthorizedUseOfEncryptedAmount(euint64 amount, address user);
 
-    /// @dev The module is already installed for the given token.
-    error ERC7984HookModuleAlreadyInstalled(address token);
-
-    /// @dev The module is not installed for the given token.
-    error ERC7984HookModuleNotInstalled(address token);
-
-    mapping(address token => bool) private _installed;
-
     /// @inheritdoc IERC7984HookModule
     function preTransfer(address from, address to, euint64 encryptedAmount) public virtual returns (ebool) {
         require(
@@ -47,16 +39,7 @@ abstract contract ERC7984HookModule is IERC7984HookModule, ERC165 {
 
     /// @inheritdoc IERC7984HookModule
     function onInstall(bytes calldata initData) public virtual {
-        require(!_isModuleInstalled(msg.sender), ERC7984HookModuleAlreadyInstalled(msg.sender));
-
         _onInstall(msg.sender, initData);
-    }
-
-    /// @inheritdoc IERC7984HookModule
-    function onUninstall(bytes calldata deinitData) public virtual {
-        require(_isModuleInstalled(msg.sender), ERC7984HookModuleNotInstalled(msg.sender));
-
-        _onUninstall(msg.sender, deinitData);
     }
 
     /// @inheritdoc ERC165
@@ -68,17 +51,7 @@ abstract contract ERC7984HookModule is IERC7984HookModule, ERC165 {
      * @dev Internal function which may be overridden by the derived contract to perform actions
      * when the module is installed.
      */
-    function _onInstall(address token, bytes calldata /* initData */) internal virtual {
-        _installed[token] = true;
-    }
-
-    /**
-     * @dev Internal function which may be overridden by the derived contract to perform actions
-     * when the module is uninstalled.
-     */
-    function _onUninstall(address token, bytes calldata /* deinitData */) internal virtual {
-        delete _installed[token];
-    }
+    function _onInstall(address /* token */, bytes calldata /* initData */) internal virtual {}
 
     /**
      * @dev Internal function which runs before a transfer. Transient access is already granted to the module
@@ -108,18 +81,6 @@ abstract contract ERC7984HookModule is IERC7984HookModule, ERC165 {
         euint64 /*encryptedAmount*/
     ) internal virtual {
         // default to no-op
-    }
-
-    /**
-     * @dev Check if the module is installed for the given token. The default implementation reads from
-     * an internal storage flag maintained by {onInstall} and {onUninstall}. Derived contracts may override
-     * to extend the check, but should typically rely on the default behavior.
-     *
-     * NOTE: This function should use internal storage to check if the module is installed for the given token.
-     * Do not use external storage like {ERC7984Hooked-isModuleInstalled}.
-     */
-    function _isModuleInstalled(address token) internal view virtual returns (bool) {
-        return _installed[token];
     }
 
     /// @dev Allow modules to get access to token handles during transaction.

--- a/test/helpers/interface.ts
+++ b/test/helpers/interface.ts
@@ -55,7 +55,6 @@ export const SIGNATURES = {
     'preTransfer(address,address,bytes32)',
     'postTransfer(address,address,bytes32)',
     'onInstall(bytes)',
-    'onUninstall(bytes)',
   ],
 };
 

--- a/test/token/ERC7984/extensions/ERC7984Hooked.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984Hooked.test.ts
@@ -85,7 +85,7 @@ describe('ERC7984Hooked', function () {
     });
 
     it('should emit event', async function () {
-      await expect(this.token.$_uninstallModule(this.hookModule, '0x'))
+      await expect(this.token.$_uninstallModule(this.hookModule))
         .to.emit(this.token, 'ERC7984HookedModuleUninstalled')
         .withArgs(this.hookModule);
     });
@@ -93,33 +93,22 @@ describe('ERC7984Hooked', function () {
     it('should fail if module not installed', async function () {
       const newModule = await ethers.deployContract('$ERC7984HookModuleMock');
 
-      await expect(this.token.$_uninstallModule(newModule, '0x'))
+      await expect(this.token.$_uninstallModule(newModule))
         .to.be.revertedWithCustomError(this.token, 'ERC7984HookedNonexistentModule')
         .withArgs(newModule);
     });
 
-    it('should call `onUninstall` on the module', async function () {
-      await expect(this.token.$_uninstallModule(this.hookModule, '0xffff'))
-        .to.emit(this.hookModule, 'OnUninstall')
-        .withArgs('0xffff');
-    });
-
     it('should remove module from modules list', async function () {
-      await this.token.$_uninstallModule(this.hookModule, '0x');
+      await this.token.$_uninstallModule(this.hookModule);
       await expect(this.token.isModuleInstalled(this.hookModule)).to.eventually.be.false;
     });
 
-    it("should not revert if module's `onUninstall` reverts", async function () {
-      await this.hookModule.setRevertOnUninstall(true);
-      await this.token.$_uninstallModule(this.hookModule, '0x');
-    });
-
     it('should gate via `_authorizeModuleChange`', async function () {
-      await expect(this.token.connect(this.anyone).uninstallModule(this.hookModule, '0x'))
+      await expect(this.token.connect(this.anyone).uninstallModule(this.hookModule))
         .to.be.revertedWithCustomError(this.token, 'OwnableUnauthorizedAccount')
         .withArgs(this.anyone);
 
-      await this.token.connect(this.admin).uninstallModule(this.hookModule, '0x');
+      await this.token.connect(this.admin).uninstallModule(this.hookModule);
       await expect(this.token.isModuleInstalled(this.hookModule)).to.eventually.be.false;
     });
   });

--- a/test/token/ERC7984/utils/ERC7984BalanceCapHookModule.test.ts
+++ b/test/token/ERC7984/utils/ERC7984BalanceCapHookModule.test.ts
@@ -42,40 +42,13 @@ describe('ERC7984BalanceCapHookModule', function () {
       holder,
       anyone,
       encryptCap,
+      initialCap: ethers.hexlify(encryptedInput.handles[0]),
     });
   });
 
   describe('_onInstall', function () {
-    it('should mark the module as installed and set the initial cap from initData', async function () {
-      await this.token.connect(this.admin).uninstallModule(this.complianceModule, '0x');
-
-      const encryptedInput = await fhevm
-        .createEncryptedInput(this.complianceModule.target, this.token.target)
-        .add64(10_000n)
-        .encrypt();
-
-      await this.token
-        .connect(this.admin)
-        .installModule(
-          this.complianceModule,
-          ethers.AbiCoder.defaultAbiCoder().encode(
-            ['bytes32', 'bytes'],
-            [encryptedInput.handles[0], encryptedInput.inputProof],
-          ),
-        );
-
-      await expect(this.complianceModule.$_isModuleInstalled(this.token)).to.eventually.equal(true);
-      await expect(this.complianceModule.maxBalance(this.token)).to.eventually.eq(
-        ethers.hexlify(encryptedInput.handles[0]),
-      );
-    });
-  });
-
-  describe('_onUninstall', function () {
-    it('should clean up state', async function () {
-      await this.token.connect(this.admin).uninstallModule(this.complianceModule, '0x');
-      await expect(this.complianceModule.maxBalance(this.token)).to.eventually.eq(ethers.ZeroHash);
-      await expect(this.complianceModule.$_isModuleInstalled(this.token)).to.eventually.equal(false);
+    it('should set the initial cap from initData', async function () {
+      await expect(this.complianceModule.maxBalance(this.token)).to.eventually.eq(this.initialCap);
     });
   });
 

--- a/test/token/ERC7984/utils/ERC7984HolderCapHookModules.test.ts
+++ b/test/token/ERC7984/utils/ERC7984HolderCapHookModules.test.ts
@@ -49,25 +49,6 @@ describe('ERC7984HolderCapHookModules', function () {
     });
   });
 
-  describe('_onUninstall', function () {
-    it('should clean up state', async function () {
-      await this.token.connect(this.admin).uninstallModule(this.complianceModule, '0x');
-      await expect(this.complianceModule.maxHolderCount(this.token)).to.eventually.eq(0);
-      await expect(this.complianceModule.holderCount(this.token)).to.eventually.eq(0n);
-    });
-  });
-
-  describe('_onInstall', function () {
-    it('should revert if total supply is already initialized', async function () {
-      await this.token.connect(this.admin).uninstallModule(this.complianceModule, '0x');
-      await expect(
-        this.token
-          .connect(this.admin)
-          .installModule(this.complianceModule, ethers.AbiCoder.defaultAbiCoder().encode(['uint64'], [10])),
-      ).to.be.revertedWithCustomError(this.complianceModule, 'ERC7984HolderCapHookModuleTotalSupplyInitialized');
-    });
-  });
-
   describe('_preTransfer', function () {
     it('should allow transfer if new holder count is less than max holder count', async function () {
       const tx = await this.token.connect(this.holder)['confidentialTransfer(address,uint64)'](this.recipient, 1000);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated hook module lifecycle to prioritize initialization on install rather than cleanup on uninstall.
  * Simplified module removal API by eliminating data requirements from the uninstall function.

* **Tests**
  * Updated test coverage to reflect new hook module initialization and lifecycle behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/openzeppelin-confidential-contracts/pull/380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->