### PR TITLE
Block usage of `Context`

### DIFF
--- a/.changeset/eager-icons-own.md
+++ b/.changeset/eager-icons-own.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': minor
+---
+
+`ERC7984Rwa`: block overrides of `Context` functions (`_msgSender()`, `_msgData()`)

--- a/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
@@ -288,4 +288,14 @@ abstract contract ERC7984Rwa is IERC7984Rwa, ERC7984Freezable, ERC7984Restricted
             selector == 0x44fd6e40 || // bytes4(keccak256("forceConfidentialTransferFrom(address,address,bytes32)"))
             selector == this.recoverAddress.selector;
     }
+
+    /// @dev Restrict overrides of {Context._msgSender}. Please use other account abstraction methods instead.
+    function _msgSender() internal view override returns (address) {
+        return super._msgSender();
+    }
+
+    /// @dev Restrict overrides of {Context._msgData}. Please use other account abstraction methods instead.
+    function _msgData() internal view override returns (bytes calldata) {
+        return super._msgData();
+    }
 }


### PR DESCRIPTION
Fixes #319

We don't intend for these contracts to be used with ERC-2771 meta transactions. The Zama library doesn't support overriding `msg.sender`. The simplest solution is to just fully block the usage overall.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced ERC7984Rwa with improved handling of context sender and data functions through block-level overrides, enabling more controlled context value management.

* **Chores**
  * Updated openzeppelin-confidential-contracts version metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/openzeppelin-confidential-contracts/pull/382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->