### PR TITLE
Document `ERC7984` operator ACL access

### DIFF
--- a/contracts/token/ERC7984/ERC7984.sol
+++ b/contracts/token/ERC7984/ERC7984.sol
@@ -100,7 +100,10 @@ abstract contract ERC7984 is IERC7984, ERC165 {
         return holder == spender || block.timestamp <= _operators[holder][spender];
     }
 
-    /// @inheritdoc IERC7984
+    /**
+     * @dev See {IERC7984-setOperator}. Operators are given ACL allowance (ability to decrypt) for the transferred amount
+     * of transfers they initiate.
+     */
     function setOperator(address operator, uint48 until) public virtual {
         _setOperator(msg.sender, operator, until);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation for operator functionality to clarify permissions granted to operators when transfers are initiated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->