### PR TITLE
Ensure `BatcherConfidential` intermediate steps do not transfer underlying `toToken`

### DIFF
--- a/.changeset/tasty-badgers-walk.md
+++ b/.changeset/tasty-badgers-walk.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': minor
+---
+
+`BatcherConfidential`: revert if underlying to tokens are received during a partial route execution/

--- a/.changeset/tasty-badgers-walk.md
+++ b/.changeset/tasty-badgers-walk.md
@@ -2,4 +2,4 @@
 'openzeppelin-confidential-contracts': minor
 ---
 
-`BatcherConfidential`: revert if underlying to tokens are received during a partial route execution/
+`BatcherConfidential`: revert if underlying to token balance changes during a partial route execution.

--- a/.changeset/tasty-badgers-walk.md
+++ b/.changeset/tasty-badgers-walk.md
@@ -2,4 +2,4 @@
 'openzeppelin-confidential-contracts': minor
 ---
 
-`BatcherConfidential`: revert if underlying to token balance changes during a partial route execution.
+`BatcherConfidential`: revert if underlying `toToken` balance changes during a partial route execution.

--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -113,6 +113,9 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
     /// @dev The underlying wrapper tokens are the same.
     error DuplicateUnderlyingTokens();
 
+    /// @dev Intermediate steps must not result in underlying {toToken} being transferred into the batcher.
+    error IntermediateStepInvalidToTokenTransfer(uint256 batchId);
+
     constructor(IERC7984ERC20Wrapper fromToken_, IERC7984ERC20Wrapper toToken_) {
         require(
             ERC165Checker.supportsInterface(address(fromToken_), type(IERC7984ERC20Wrapper).interfaceId),
@@ -220,10 +223,13 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
             FHE.checkSignatures(handles, abi.encode(unwrapAmountCleartext), decryptionProof);
         }
 
+        uint256 beforeToTokenBalance;
+
         ExecuteOutcome outcome;
         if (unwrapAmountCleartext == 0) {
             outcome = ExecuteOutcome.Cancel;
         } else {
+            beforeToTokenBalance = IERC20(toToken().underlying()).balanceOf(address(this));
             outcome = _executeRoute(batchId, unwrapAmountCleartext);
         }
 
@@ -255,6 +261,11 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
             _batches[batchId].canceled = true;
 
             emit BatchCanceled(batchId);
+        } else if (outcome == ExecuteOutcome.Partial) {
+            require(
+                IERC20(toToken().underlying()).balanceOf(address(this)) == beforeToTokenBalance,
+                IntermediateStepInvalidToTokenTransfer(batchId)
+            );
         }
     }
 

--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -223,13 +223,13 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
             FHE.checkSignatures(handles, abi.encode(unwrapAmountCleartext), decryptionProof);
         }
 
-        uint256 beforeToTokenBalance;
+        uint256 beforeUnderlyingToTokenBalance;
 
         ExecuteOutcome outcome;
         if (unwrapAmountCleartext == 0) {
             outcome = ExecuteOutcome.Cancel;
         } else {
-            beforeToTokenBalance = IERC20(toToken().underlying()).balanceOf(address(this));
+            beforeUnderlyingToTokenBalance = IERC20(toToken().underlying()).balanceOf(address(this));
             outcome = _executeRoute(batchId, unwrapAmountCleartext);
         }
 
@@ -263,7 +263,7 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
             emit BatchCanceled(batchId);
         } else if (outcome == ExecuteOutcome.Partial) {
             require(
-                IERC20(toToken().underlying()).balanceOf(address(this)) == beforeToTokenBalance,
+                IERC20(toToken().underlying()).balanceOf(address(this)) == beforeUnderlyingToTokenBalance,
                 IntermediateStepToTokenBalanceChanged(batchId)
             );
         }

--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -114,7 +114,7 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
     error DuplicateUnderlyingTokens();
 
     /// @dev Intermediate steps must not result in underlying {toToken} being transferred into the batcher.
-    error IntermediateStepInvalidToTokenTransfer(uint256 batchId);
+    error IntermediateStepToTokenBalanceChanged(uint256 batchId);
 
     constructor(IERC7984ERC20Wrapper fromToken_, IERC7984ERC20Wrapper toToken_) {
         require(
@@ -264,7 +264,7 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
         } else if (outcome == ExecuteOutcome.Partial) {
             require(
                 IERC20(toToken().underlying()).balanceOf(address(this)) == beforeToTokenBalance,
-                IntermediateStepInvalidToTokenTransfer(batchId)
+                IntermediateStepToTokenBalanceChanged(batchId)
             );
         }
     }
@@ -415,7 +415,7 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
      *
      * NOTE: {dispatchBatchCallback} (and in turn {_executeRoute}) can be repeatedly called until the route execution is complete.
      * If a multi-step route is necessary, intermediate steps should return `ExecuteOutcome.Partial`. Intermediate steps *must* not
-     * result in underlying {toToken} being transferred into the batcher.
+     * result in underlying {toToken} being transferred to or from the batcher.
      *
      * [WARNING]
      * ====

--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -113,7 +113,7 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
     /// @dev The underlying wrapper tokens are the same.
     error DuplicateUnderlyingTokens();
 
-    /// @dev Intermediate steps must not result in underlying {toToken} being transferred into the batcher.
+    /// @dev Intermediate steps must not result in underlying {toToken} being transferred to or from the batcher.
     error IntermediateStepToTokenBalanceChanged(uint256 batchId);
 
     constructor(IERC7984ERC20Wrapper fromToken_, IERC7984ERC20Wrapper toToken_) {

--- a/contracts/mocks/finance/BatcherConfidentialSwapMock.sol
+++ b/contracts/mocks/finance/BatcherConfidentialSwapMock.sol
@@ -12,6 +12,7 @@ abstract contract BatcherConfidentialSwapMock is ZamaEthereumConfig, BatcherConf
     ExchangeMock public exchange;
     address public admin;
     ExecuteOutcome public outcome = ExecuteOutcome.Complete;
+    bool public partialTransfersToToken;
 
     constructor(ExchangeMock exchange_, address admin_) {
         exchange = exchange_;
@@ -24,6 +25,10 @@ abstract contract BatcherConfidentialSwapMock is ZamaEthereumConfig, BatcherConf
 
     function setExecutionOutcome(ExecuteOutcome outcome_) public {
         outcome = outcome_;
+    }
+
+    function setPartialTransfersToToken(bool value) public {
+        partialTransfersToToken = value;
     }
 
     /// @dev Join the current batch with `externalAmount` and `inputProof`.
@@ -68,7 +73,7 @@ abstract contract BatcherConfidentialSwapMock is ZamaEthereumConfig, BatcherConf
     }
 
     function _executeRoute(uint256, uint256 unwrapAmount) internal override returns (ExecuteOutcome) {
-        if (outcome == ExecuteOutcome.Complete) {
+        if (outcome == ExecuteOutcome.Complete || (outcome == ExecuteOutcome.Partial && partialTransfersToToken)) {
             // Approve exchange to spend unwrapped tokens
             uint256 rawAmount = unwrapAmount * fromToken().rate();
             IERC20(fromToken().underlying()).approve(address(exchange), rawAmount);

--- a/test/finance/BatcherConfidential.test.ts
+++ b/test/finance/BatcherConfidential.test.ts
@@ -32,7 +32,7 @@ function encodeStateBitmap(...states: BatchState[]): bigint {
   return states.reduce((acc, state) => acc | (1n << BigInt(state)), 0n);
 }
 
-describe.only('BatcherConfidential', function () {
+describe('BatcherConfidential', function () {
   beforeEach(async function () {
     const accounts = await ethers.getSigners();
     const [holder, recipient, operator] = accounts;
@@ -539,7 +539,7 @@ describe.only('BatcherConfidential', function () {
       await this.batcher.setPartialTransfersToToken(true);
 
       await expect(this.batcher.dispatchBatchCallback(this.batchId, this.abiEncodedClearValues, this.decryptionProof))
-        .to.be.revertedWithCustomError(this.batcher, 'IntermediateStepInvalidToTokenTransfer')
+        .to.be.revertedWithCustomError(this.batcher, 'IntermediateStepToTokenBalanceChanged')
         .withArgs(this.batchId);
     });
 
@@ -553,7 +553,7 @@ describe.only('BatcherConfidential', function () {
       // A subsequent partial step that incorrectly transfers toToken underlying in must revert.
       await this.batcher.setPartialTransfersToToken(true);
       await expect(this.batcher.dispatchBatchCallback(this.batchId, this.abiEncodedClearValues, this.decryptionProof))
-        .to.be.revertedWithCustomError(this.batcher, 'IntermediateStepInvalidToTokenTransfer')
+        .to.be.revertedWithCustomError(this.batcher, 'IntermediateStepToTokenBalanceChanged')
         .withArgs(this.batchId);
 
       // Batch state must still be Dispatched and recoverable with a clean step afterwards.

--- a/test/finance/BatcherConfidential.test.ts
+++ b/test/finance/BatcherConfidential.test.ts
@@ -32,7 +32,7 @@ function encodeStateBitmap(...states: BatchState[]): bigint {
   return states.reduce((acc, state) => acc | (1n << BigInt(state)), 0n);
 }
 
-describe('BatcherConfidential', function () {
+describe.only('BatcherConfidential', function () {
   beforeEach(async function () {
     const accounts = await ethers.getSigners();
     const [holder, recipient, operator] = accounts;
@@ -532,6 +532,38 @@ describe('BatcherConfidential', function () {
       await expect(this.batcher.dispatchBatchCallback(this.batchId, this.abiEncodedClearValues, this.decryptionProof))
         .to.emit(this.batcher, 'BatchFinalized')
         .withArgs(this.batchId, 10n ** 6n);
+    });
+
+    it('should revert if `_executeRoute` returns partial but transferred toToken underlying in', async function () {
+      await this.batcher.setExecutionOutcome(ExecuteOutcome.Partial);
+      await this.batcher.setPartialTransfersToToken(true);
+
+      await expect(this.batcher.dispatchBatchCallback(this.batchId, this.abiEncodedClearValues, this.decryptionProof))
+        .to.be.revertedWithCustomError(this.batcher, 'IntermediateStepInvalidToTokenTransfer')
+        .withArgs(this.batchId);
+    });
+
+    it('should revert on partial-with-transfer even after prior clean partial steps', async function () {
+      await this.batcher.setExecutionOutcome(ExecuteOutcome.Partial);
+
+      // A few legitimate partial steps that don't transfer toToken in.
+      await this.batcher.dispatchBatchCallback(this.batchId, this.abiEncodedClearValues, this.decryptionProof);
+      await this.batcher.dispatchBatchCallback(this.batchId, this.abiEncodedClearValues, this.decryptionProof);
+
+      // A subsequent partial step that incorrectly transfers toToken underlying in must revert.
+      await this.batcher.setPartialTransfersToToken(true);
+      await expect(this.batcher.dispatchBatchCallback(this.batchId, this.abiEncodedClearValues, this.decryptionProof))
+        .to.be.revertedWithCustomError(this.batcher, 'IntermediateStepInvalidToTokenTransfer')
+        .withArgs(this.batchId);
+
+      // Batch state must still be Dispatched and recoverable with a clean step afterwards.
+      await expect(this.batcher.batchState(this.batchId)).to.eventually.eq(BatchState.Dispatched);
+
+      await this.batcher.setPartialTransfersToToken(false);
+      await this.batcher.setExecutionOutcome(ExecuteOutcome.Complete);
+      await expect(
+        this.batcher.dispatchBatchCallback(this.batchId, this.abiEncodedClearValues, this.decryptionProof),
+      ).to.emit(this.batcher, 'BatchFinalized');
     });
 
     it('should be able to call multiple times if `_executeRoute` returns partial', async function () {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * BatcherConfidential now reverts when underlying tokens are received during partial route execution, strengthening contract safety and preventing invalid states.

* **Tests**
  * Added comprehensive test coverage for partial route execution scenarios, including multi-step routes and token transfer validation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->