### PR TITLE
Enable decryption of the `joinedAmount` in `BatcherConfidential`

### DIFF
--- a/.changeset/few-hotels-scream.md
+++ b/.changeset/few-hotels-scream.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': minor
+---
+
+`BatcherConfidential`: bug fix. Enable decryption of the `joinedAmount` in `BatcherConfidential`.

--- a/.changeset/few-hotels-scream.md
+++ b/.changeset/few-hotels-scream.md
@@ -1,5 +1,5 @@
 ---
-'openzeppelin-confidential-contracts': minor
+'openzeppelin-confidential-contracts': patch
 ---
 
 `BatcherConfidential`: bug fix. Enable decryption of the `joinedAmount` in `BatcherConfidential`.

--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -394,6 +394,7 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
 
         FHE.allowThis(newTotalDeposits);
         FHE.allowThis(newDeposits);
+        FHE.allowThis(joinedAmount);
         FHE.allow(newDeposits, to);
         FHE.allow(joinedAmount, to);
 

--- a/test/finance/BatcherConfidential.test.ts
+++ b/test/finance/BatcherConfidential.test.ts
@@ -5,6 +5,7 @@ import { FhevmType } from '@fhevm/hardhat-plugin';
 import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
+import { EventLog } from 'ethers';
 import { ethers, fhevm } from 'hardhat';
 
 const name = 'ConfidentialFungibleToken';
@@ -229,6 +230,16 @@ describe('BatcherConfidential', function () {
         await expect(join(this.fromToken, this.holder, this.batcher, 1000n))
           .to.emit(this.batcher, 'Joined')
           .withArgs(batchId, this.holder.address, anyValue);
+      });
+
+      it('should be able to decrypt joined amount', async function () {
+        const tx = await join(this.fromToken, this.holder, this.batcher, 1000n);
+        const event = (await tx.wait().then(tx => tx!.logs.filter(log => log.address === this.batcher.target)))[0];
+        const joinedAmount = (event as EventLog).data;
+
+        await expect(
+          fhevm.userDecryptEuint(FhevmType.euint64, joinedAmount, this.batcher, this.holder),
+        ).to.eventually.eq('1000');
       });
 
       it('should not credit failed transaction', async function () {


### PR DESCRIPTION
Add `FHE.allowThis` for the `joinedAmount` in `BatcherConfidential`. This is required for users to decrypt the event value off-chain.