### PR TITLE
Minimize pragmas and add script

### DIFF
--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.4.1) (finance/BatcherConfidential.sol)
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {FHE, externalEuint64, euint64, ebool} from "@fhevm/solidity/lib/FHE.sol";
 import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";

--- a/contracts/finance/VestingWalletCliffConfidential.sol
+++ b/contracts/finance/VestingWalletCliffConfidential.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.3.0) (finance/VestingWalletCliffConfidential.sol)
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {euint128} from "@fhevm/solidity/lib/FHE.sol";
 import {VestingWalletConfidential} from "./VestingWalletConfidential.sol";

--- a/contracts/finance/VestingWalletConfidentialFactory.sol
+++ b/contracts/finance/VestingWalletConfidentialFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.3.0) (finance/VestingWalletConfidentialFactory.sol)
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.24;
 
 import {FHE, euint64, externalEuint64} from "@fhevm/solidity/lib/FHE.sol";
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";

--- a/contracts/interfaces/IERC7984.sol
+++ b/contracts/interfaces/IERC7984.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.3.0) (interfaces/IERC7984.sol)
-pragma solidity ^0.8.24;
+pragma solidity >=0.8.24;
 
 import {euint64, externalEuint64} from "@fhevm/solidity/lib/FHE.sol";
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";

--- a/contracts/interfaces/IERC7984ERC20Wrapper.sol
+++ b/contracts/interfaces/IERC7984ERC20Wrapper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.4.0) (interfaces/IERC7984ERC20Wrapper.sol)
 
-pragma solidity ^0.8.24;
+pragma solidity >=0.8.24;
 
 import {externalEuint64, euint64} from "@fhevm/solidity/lib/FHE.sol";
 import {IERC7984} from "./IERC7984.sol";

--- a/contracts/interfaces/IERC7984HookModule.sol
+++ b/contracts/interfaces/IERC7984HookModule.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity >=0.8.24;
 
 import {euint64, ebool} from "@fhevm/solidity/lib/FHE.sol";
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";

--- a/contracts/interfaces/IERC7984Receiver.sol
+++ b/contracts/interfaces/IERC7984Receiver.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.4.0) (interfaces/IERC7984Receiver.sol)
-pragma solidity ^0.8.24;
+pragma solidity >=0.8.24;
 
 import {ebool, euint64} from "@fhevm/solidity/lib/FHE.sol";
 

--- a/contracts/interfaces/IERC7984Rwa.sol
+++ b/contracts/interfaces/IERC7984Rwa.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.4.0) (interfaces/IERC7984Rwa.sol)
-pragma solidity ^0.8.24;
+pragma solidity >=0.8.24;
 
 import {externalEuint64, euint64} from "@fhevm/solidity/lib/FHE.sol";
 import {IERC7984} from "./IERC7984.sol";

--- a/contracts/token/ERC7984/ERC7984.sol
+++ b/contracts/token/ERC7984/ERC7984.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.3.0) (token/ERC7984/ERC7984.sol)
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {FHE, externalEuint64, ebool, euint64} from "@fhevm/solidity/lib/FHE.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";

--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.4.0) (token/ERC7984/extensions/ERC7984ERC20Wrapper.sol)
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {FHE, externalEuint64, euint64} from "@fhevm/solidity/lib/FHE.sol";
 import {IERC1363Receiver} from "@openzeppelin/contracts/interfaces/IERC1363Receiver.sol";

--- a/contracts/token/ERC7984/extensions/ERC7984Freezable.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Freezable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.4.0) (token/ERC7984/extensions/ERC7984Freezable.sol)
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {FHE, euint64} from "@fhevm/solidity/lib/FHE.sol";
 import {FHESafeMath} from "../../../utils/FHESafeMath.sol";

--- a/contracts/token/ERC7984/extensions/ERC7984Hooked.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Hooked.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {FHE, ebool, euint64} from "@fhevm/solidity/lib/FHE.sol";
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";

--- a/contracts/token/ERC7984/extensions/ERC7984IdentityCheck.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984IdentityCheck.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {euint64} from "@fhevm/solidity/lib/FHE.sol";
 import {ERC7984} from "../ERC7984.sol";

--- a/contracts/token/ERC7984/extensions/ERC7984ObserverAccess.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ObserverAccess.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.4.0) (token/ERC7984/extensions/ERC7984ObserverAccess.sol)
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {FHE, euint64} from "@fhevm/solidity/lib/FHE.sol";
 import {ERC7984} from "../ERC7984.sol";

--- a/contracts/token/ERC7984/extensions/ERC7984Omnibus.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Omnibus.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.3.0) (token/ERC7984/extensions/ERC7984Omnibus.sol)
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {FHE, euint64, externalEuint64, externalEaddress, eaddress} from "@fhevm/solidity/lib/FHE.sol";
 import {ERC7984} from "../ERC7984.sol";

--- a/contracts/token/ERC7984/extensions/ERC7984Restricted.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Restricted.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.4.0) (token/ERC7984/extensions/ERC7984Restricted.sol)
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {ERC7984, euint64} from "../ERC7984.sol";
 

--- a/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Rwa.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.4.0) (token/ERC7984/extensions/ERC7984Rwa.sol)
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {FHE, externalEuint64, euint64} from "@fhevm/solidity/lib/FHE.sol";
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";

--- a/contracts/token/ERC7984/extensions/ERC7984Votes.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Votes.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.4.0) (token/ERC7984/extensions/ERC7984Votes.sol)
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {euint64} from "@fhevm/solidity/lib/FHE.sol";
 import {VotesConfidential} from "../../../governance/utils/VotesConfidential.sol";

--- a/contracts/token/ERC7984/utils/ERC7984HookModule.sol
+++ b/contracts/token/ERC7984/utils/ERC7984HookModule.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {FHE, ebool, euint64} from "@fhevm/solidity/lib/FHE.sol";
 import {ERC165, IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";

--- a/contracts/token/ERC7984/utils/ERC7984Utils.sol
+++ b/contracts/token/ERC7984/utils/ERC7984Utils.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.3.0) (token/ERC7984/utils/ERC7984Utils.sol)
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.26;
 
 import {FHE, ebool, euint64} from "@fhevm/solidity/lib/FHE.sol";
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:sol": "prettier --loglevel warn '{contracts,test}/**/*.sol' --check && solhint --config solhint.config.js '{contracts,test}/**/*.sol'",
     "lint:sol:fix": "solhint --config solhint.config.js '{contracts,test}/**/*.sol' --fix; prettier --loglevel warn '{contracts,test}/**/*.sol' --write",
     "postinstall": "rimraf fhevmTemp",
+    "pragma": "npm run compile && scripts/minimize-pragma.js artifacts/build-info/*",
     "prepack": "scripts/prepack.sh",
     "prepare": "husky",
     "prepare-docs": "scripts/prepare-docs.sh",

--- a/scripts/minimize-pragma.js
+++ b/scripts/minimize-pragma.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const graphlib = require('graphlib');
+const semver = require('semver');
+const pLimit = require('p-limit').default;
+const { hideBin } = require('yargs/helpers');
+const yargs = require('yargs/yargs');
+
+const getContractsMetadata = require('./get-contracts-metadata');
+const { versions: allSolcVersions, compile } = require('./solc-versions');
+
+const {
+  argv: { pattern, skipPatterns, minVersionForContracts, minVersionForInterfaces, concurrency, _: artifacts },
+} = yargs(hideBin(process.argv))
+  .env('')
+  .options({
+    pattern: { alias: 'p', type: 'string', default: 'contracts/**/*.sol' },
+    skipPatterns: { alias: 's', type: 'string', default: 'contracts/mocks/**/*.sol' },
+    minVersionForContracts: { type: 'string', default: '0.8.20' },
+    minVersionForInterfaces: { type: 'string', default: '0.0.0' },
+    concurrency: { alias: 'c', type: 'number', default: 8 },
+  });
+
+// limit concurrency
+const limit = pLimit(concurrency);
+
+/********************************************************************************************************************
+ *                                                     HELPERS                                                      *
+ ********************************************************************************************************************/
+
+/**
+ * Updates the pragma in the given file to the newPragma version.
+ * @param {*} file Absolute path to the file to update.
+ * @param {*} pragma New pragma version to set. (ex: '>=0.8.4')
+ */
+const updatePragma = (file, pragma) =>
+  fs.writeFileSync(
+    file,
+    fs
+      .readFileSync(file, 'utf8')
+      .replace(/pragma solidity [><=^]*[0-9]+\.[0-9]+\.[0-9]+;/, `pragma solidity ${pragma};`),
+    'utf8',
+  );
+
+/**
+ * Get the applicable pragmas for a given file by compiling it with all solc versions.
+ * @param {*} file Absolute path to the file to compile.
+ * @param {*} candidates List of solc version to test. (ex: ['0.8.4','0.8.5'])
+ * @returns {Promise<string[]>} List of applicable pragmas.
+ */
+const getApplicablePragmas = (file, candidates = allSolcVersions) =>
+  Promise.all(
+    candidates.map(version =>
+      limit(() =>
+        compile(file, version).then(
+          () => version,
+          () => null,
+        ),
+      ),
+    ),
+  ).then(versions => versions.filter(Boolean));
+
+/**
+ * Get the minimum applicable pragmas for a given file.
+ * @param {*} file Absolute path to the file to compile.
+ * @param {*} candidates List of solc version to test. (ex: ['0.8.4','0.8.5'])
+ * @returns {Promise<string>} Smallest applicable pragma out of the list.
+ */
+const getMinimalApplicablePragma = (file, candidates = allSolcVersions) =>
+  getApplicablePragmas(file, candidates).then(valid => {
+    if (valid.length == 0) {
+      throw new Error(`No valid pragma found for ${file}`);
+    } else {
+      return valid.sort(semver.compare).at(0);
+    }
+  });
+
+/**
+ * Get the minimum applicable pragmas for a given file, and update the file to use it.
+ * @param {*} file Absolute path to the file to compile.
+ * @param {*} candidates List of solc version to test. (ex: ['0.8.4','0.8.5'])
+ * @param {*} prefix Prefix to use when building the pragma (ex: '^')
+ * @returns {Promise<string>} Version that was used and set in the file
+ */
+const setMinimalApplicablePragma = (file, candidates = allSolcVersions, prefix = '>=') =>
+  getMinimalApplicablePragma(file, candidates)
+    .then(version => `${prefix}${version}`)
+    .then(pragma => {
+      updatePragma(file, pragma);
+      return pragma;
+    });
+
+/********************************************************************************************************************
+ *                                                       MAIN                                                       *
+ ********************************************************************************************************************/
+
+// Build metadata from artifact files (hardhat compilation)
+const metadata = getContractsMetadata(pattern, skipPatterns, artifacts);
+
+// Build dependency graph
+const graph = new graphlib.Graph({ directed: true });
+Object.keys(metadata).forEach(file => {
+  graph.setNode(file);
+  metadata[file].sources.forEach(dep => graph.setEdge(dep, file));
+});
+
+// Weaken all pragma to allow exploration
+Object.keys(metadata).forEach(file => updatePragma(file, '>=0.0.0'));
+
+// Do a topological traversal of the dependency graph, minimizing pragma for each file we encounter
+(async () => {
+  const queue = graph.sources();
+  const pragmas = {};
+  while (queue.length) {
+    const file = queue.shift();
+    if (!Object.hasOwn(pragmas, file)) {
+      if (Object.hasOwn(metadata, file)) {
+        const minVersion = metadata[file].interface ? minVersionForInterfaces : minVersionForContracts;
+        const parentsPragmas = graph
+          .predecessors(file)
+          .map(file => pragmas[file])
+          .filter(Boolean);
+        const candidates = allSolcVersions.filter(
+          v => semver.gte(v, minVersion) && parentsPragmas.every(p => semver.satisfies(v, p)),
+        );
+        const pragmaPrefix = metadata[file].interface ? '>=' : '^';
+
+        process.stdout.write(
+          `[${Object.keys(pragmas).length + 1}/${
+            Object.keys(metadata).length
+          }] Searching minimal version for ${file} ... `,
+        );
+        const pragma = await setMinimalApplicablePragma(file, candidates, pragmaPrefix);
+        console.log(pragma);
+
+        pragmas[file] = pragma;
+      }
+      queue.push(...graph.successors(file));
+    }
+  }
+})();


### PR DESCRIPTION
The pragma minimization script was ported over from vanilla (unfortunately, symlinks couldn't be used due to how the build artifacts are imported). The script was run as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Solidity compiler version requirements across multiple contracts for improved compatibility and flexibility.
  * Added automated build tooling to optimize and minimize compiler pragma versions during the build process, improving version management efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->