### PR TITLE
Initialize zero value on empty `dispatchBatch`

### DIFF
--- a/.changeset/eleven-planets-obey.md
+++ b/.changeset/eleven-planets-obey.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': patch
+---
+
+`BatcherConfidential`: Initialize the zero value before unwrapping when dispatching a batch with no contributions.

--- a/.changeset/empty-batch-dispatch-handle.md
+++ b/.changeset/empty-batch-dispatch-handle.md
@@ -2,4 +2,4 @@
 'openzeppelin-confidential-contracts': patch
 ---
 
-`BatcherConfidential`: Materialize the unwrap handle when dispatching an empty batch so dispatch passes a real, transiently-allowed handle to `fromToken().unwrap` instead of the raw uninitialized (zero) handle.
+`BatcherConfidential`: Use the ignored returned value of `allowTransient` (fix for uninitialized handles).

--- a/.changeset/empty-batch-dispatch-handle.md
+++ b/.changeset/empty-batch-dispatch-handle.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': patch
+---
+
+`BatcherConfidential`: Materialize the unwrap handle when dispatching an empty batch so dispatch passes a real, transiently-allowed handle to `fromToken().unwrap` instead of the raw uninitialized (zero) handle.

--- a/.changeset/empty-batch-dispatch-handle.md
+++ b/.changeset/empty-batch-dispatch-handle.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-confidential-contracts': patch
----
-
-`BatcherConfidential`: Use the ignored returned value of `allowTransient` (fix for uninitialized handles).

--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -188,7 +188,10 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
     function dispatchBatch() public virtual {
         uint256 batchId = _getAndIncreaseBatchId();
 
-        euint64 amountToUnwrap = FHE.allowTransient(totalDeposits(batchId), address(fromToken()));
+        euint64 amountToUnwrap = totalDeposits(batchId);
+        if (!FHE.isInitialized(amountToUnwrap)) amountToUnwrap = FHE.asEuint64(0);
+
+        FHE.allowTransient(amountToUnwrap, address(fromToken()));
         _batches[batchId].unwrapRequestId = fromToken().unwrap(
             address(this),
             address(this),

--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -188,10 +188,6 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
     function dispatchBatch() public virtual {
         uint256 batchId = _getAndIncreaseBatchId();
 
-        // For an empty batch `totalDeposits` is uninitialized; `allowTransient` materializes it
-        // into a real, transiently-allowed handle and returns it. Unwrapping that handle (never the
-        // raw zero handle) keeps dispatch working against a `fromToken` whose `fromExternal` does not
-        // treat the zero handle as an encrypted zero and would otherwise revert `SenderNotAllowedToUseHandle`.
         euint64 amountToUnwrap = FHE.allowTransient(totalDeposits(batchId), address(fromToken()));
         _batches[batchId].unwrapRequestId = fromToken().unwrap(
             address(this),

--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -188,8 +188,11 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
     function dispatchBatch() public virtual {
         uint256 batchId = _getAndIncreaseBatchId();
 
-        euint64 amountToUnwrap = totalDeposits(batchId);
-        FHE.allowTransient(amountToUnwrap, address(fromToken()));
+        // For an empty batch `totalDeposits` is uninitialized; `allowTransient` materializes it
+        // into a real, transiently-allowed handle and returns it. Unwrapping that handle (never the
+        // raw zero handle) keeps dispatch working against a `fromToken` whose `fromExternal` does not
+        // treat the zero handle as an encrypted zero and would otherwise revert `SenderNotAllowedToUseHandle`.
+        euint64 amountToUnwrap = FHE.allowTransient(totalDeposits(batchId), address(fromToken()));
         _batches[batchId].unwrapRequestId = fromToken().unwrap(
             address(this),
             address(this),

--- a/test/finance/BatcherConfidential.test.ts
+++ b/test/finance/BatcherConfidential.test.ts
@@ -506,6 +506,36 @@ describe('BatcherConfidential', function () {
     });
   });
 
+  describe('dispatchBatch with an empty batch', function () {
+    // An empty batch has an uninitialized `totalDeposits`. Dispatch must materialize it and hand
+    // `fromToken` a real, transiently-allowed handle, so a wrapper whose `fromExternal` rejects the
+    // raw zero handle cannot brick the route.
+    it('dispatches with an unwrap amount of zero', async function () {
+      const batchId = await this.batcher.currentBatchId();
+
+      await expect(this.batcher.connect(this.holder).dispatchBatch())
+        .to.emit(this.batcher, 'BatchDispatched')
+        .withArgs(batchId);
+
+      const [, amount] = (await this.fromToken.queryFilter(this.fromToken.filters.UnwrapRequested()))[0].args;
+      const { abiEncodedClearValues } = await fhevm.publicDecrypt([amount]);
+      expect(BigInt(abiEncodedClearValues)).to.eq(0n);
+    });
+
+    it('cancels the batch on the zero-amount callback', async function () {
+      const batchId = await this.batcher.currentBatchId();
+      await this.batcher.connect(this.holder).dispatchBatch();
+
+      const [, amount] = (await this.fromToken.queryFilter(this.fromToken.filters.UnwrapRequested()))[0].args;
+      const { abiEncodedClearValues, decryptionProof } = await fhevm.publicDecrypt([amount]);
+
+      await expect(this.batcher.dispatchBatchCallback(batchId, abiEncodedClearValues, decryptionProof))
+        .to.emit(this.batcher, 'BatchCanceled')
+        .withArgs(batchId);
+      await expect(this.batcher.batchState(batchId)).to.eventually.eq(BatchState.Canceled);
+    });
+  });
+
   describe('dispatchBatchCallback', function () {
     beforeEach(async function () {
       const joinAmount = 1000n;

--- a/test/finance/BatcherConfidential.test.ts
+++ b/test/finance/BatcherConfidential.test.ts
@@ -506,36 +506,6 @@ describe('BatcherConfidential', function () {
     });
   });
 
-  describe('dispatchBatch with an empty batch', function () {
-    // An empty batch has an uninitialized `totalDeposits`. Dispatch must materialize it and hand
-    // `fromToken` a real, transiently-allowed handle, so a wrapper whose `fromExternal` rejects the
-    // raw zero handle cannot brick the route.
-    it('dispatches with an unwrap amount of zero', async function () {
-      const batchId = await this.batcher.currentBatchId();
-
-      await expect(this.batcher.connect(this.holder).dispatchBatch())
-        .to.emit(this.batcher, 'BatchDispatched')
-        .withArgs(batchId);
-
-      const [, amount] = (await this.fromToken.queryFilter(this.fromToken.filters.UnwrapRequested()))[0].args;
-      const { abiEncodedClearValues } = await fhevm.publicDecrypt([amount]);
-      expect(BigInt(abiEncodedClearValues)).to.eq(0n);
-    });
-
-    it('cancels the batch on the zero-amount callback', async function () {
-      const batchId = await this.batcher.currentBatchId();
-      await this.batcher.connect(this.holder).dispatchBatch();
-
-      const [, amount] = (await this.fromToken.queryFilter(this.fromToken.filters.UnwrapRequested()))[0].args;
-      const { abiEncodedClearValues, decryptionProof } = await fhevm.publicDecrypt([amount]);
-
-      await expect(this.batcher.dispatchBatchCallback(batchId, abiEncodedClearValues, decryptionProof))
-        .to.emit(this.batcher, 'BatchCanceled')
-        .withArgs(batchId);
-      await expect(this.batcher.batchState(batchId)).to.eventually.eq(BatchState.Canceled);
-    });
-  });
-
   describe('dispatchBatchCallback', function () {
     beforeEach(async function () {
       const joinAmount = 1000n;
@@ -642,28 +612,36 @@ describe('BatcherConfidential', function () {
     });
 
     it('should cancel if unwrap amount is 0', async function () {
-      await this.batcher.connect(this.holder).join(0n);
-
+      const batchId = await this.batcher.currentBatchId();
       await this.batcher.connect(this.holder).dispatchBatch();
 
       const [, amount] = (await this.fromToken.queryFilter(this.fromToken.filters.UnwrapRequested()))[1].args;
       const { abiEncodedClearValues, decryptionProof } = await fhevm.publicDecrypt([amount]);
 
-      await expect(this.batcher.dispatchBatchCallback(this.batchId + 1n, abiEncodedClearValues, decryptionProof))
+      await expect(this.batcher.dispatchBatchCallback(batchId, abiEncodedClearValues, decryptionProof))
         .to.emit(this.batcher, 'BatchCanceled')
-        .withArgs(this.batchId + 1n);
+        .withArgs(batchId);
     });
   });
 
   describe('dispatchBatch', function () {
-    beforeEach(async function () {
-      this.batchId = await this.batcher.currentBatchId();
-
+    it('should emit event', async function () {
+      const batchId = await this.batcher.currentBatchId();
       await this.batcher.join(1000);
+
+      await expect(this.batcher.dispatchBatch()).to.emit(this.batcher, 'BatchDispatched').withArgs(batchId);
     });
 
-    it('should emit event', async function () {
-      await expect(this.batcher.dispatchBatch()).to.emit(this.batcher, 'BatchDispatched').withArgs(this.batchId);
+    it('should dispatch with an unwrap amount of zero', async function () {
+      const batchId = await this.batcher.currentBatchId();
+
+      await expect(this.batcher.connect(this.holder).dispatchBatch())
+        .to.emit(this.batcher, 'BatchDispatched')
+        .withArgs(batchId);
+
+      const [, amount] = (await this.fromToken.queryFilter(this.fromToken.filters.UnwrapRequested()))[0].args;
+      const { abiEncodedClearValues } = await fhevm.publicDecrypt([amount]);
+      expect(BigInt(abiEncodedClearValues)).to.eq(0n);
     });
   });
 


### PR DESCRIPTION
## Problem

`BatcherConfidential.dispatchBatch()` discards the value returned by `FHE.allowTransient` and unwraps the raw `totalDeposits` handle:

```solidity
euint64 amountToUnwrap = totalDeposits(batchId);
FHE.allowTransient(amountToUnwrap, address(fromToken())); // return value dropped
_batches[batchId].unwrapRequestId = fromToken().unwrap(
    address(this),
    address(this),
    externalEuint64.wrap(euint64.unwrap(amountToUnwrap)), // raw handle
    ""
);
```

For an **empty batch**, `totalDeposits(batchId)` is uninitialized — `euint64.wrap(0)`. `FHE.allowTransient` handles this by materializing the value:

```solidity
function allowTransient(euint64 value, address account) internal returns (euint64) {
    if (!isInitialized(value)) {
        value = asEuint64(0); // materializes a real, allow-able handle
    }
    Impl.allowTransient(euint64.unwrap(value), account);
    return value; // <- the materialized handle
}
```

Because the return value is dropped, the materialization and its transient allowance are thrown away and the raw `bytes32(0)` reaches `fromToken().unwrap(...)` → `FHE.fromExternal(0, "")`. A `fromToken` whose `fromExternal` does not treat the zero handle as an encrypted zero then reverts with `SenderNotAllowedToUseHandle(0, batcher)`, and the empty batch can never be dispatched.

## Fix

Reuse the handle returned by `allowTransient`, so `unwrap` always receives a real, transiently-allowed handle:

```solidity
euint64 amountToUnwrap = FHE.allowTransient(totalDeposits(batchId), address(fromToken()));
```

Non-empty batches are unaffected: an initialized `totalDeposits` handle is returned unchanged, so the only behavioral change is that empty batches now dispatch (unwrap amount `0` → callback cancels the batch, as expected).

## Observed in the wild

A deposit batcher on Sepolia routing through a `cUSDC` wrapper compiled against a pre-`@fhevm/solidity@0.11.1` build (whose `fromExternal` lacks the zero-handle guard) is permanently stuck on an empty batch. Simulating `dispatchBatch()` reverts with:

```
SenderNotAllowedToUseHandle(0x0, <batcher>)   // selector 0x0276b5d9
```

## Note on reproducibility

`@fhevm/solidity@0.11.1` (this repo's pinned version) added a zero-handle guard to `fromExternal` (`if (inputBytes32 == 0) return asEuint64(0);`), so against the in-repo mock wrapper an empty-batch dispatch already succeeds and the revert above is not reproducible in-suite. This fix is still correct and strictly better: it makes `dispatchBatch` independent of the `fromToken`'s fhevm version (the dropped `allowTransient` return is currently dead code for the empty case), keeping the route alive against wrappers built before that guard. The added tests exercise the empty-batch dispatch + cancel lifecycle.

## Changes

- `BatcherConfidential.dispatchBatch`: reuse `FHE.allowTransient`'s materialized return value.
- Tests: empty-batch dispatch yields a zero unwrap amount and cancels on callback.
- Changeset (`patch`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an uninitialized-handle issue in batch dispatch operations by ensuring the returned value from transient allowance operations is properly utilized.

* **Tests**
  * Added test coverage for empty batch dispatch scenarios, verifying correct event emissions and state transitions for batch cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->