### PR TITLE
Revert on uninitialized total deposits in `BatcherConfidential.dispatchBatch`

### DIFF
--- a/.changeset/shaggy-roses-grab.md
+++ b/.changeset/shaggy-roses-grab.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': patch
+---
+
+`BatcherConfidential`: Revert on `dispatchBatch` if the `totalDeposits` for the given batch is uninitialized.

--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -184,7 +184,7 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
 
     /**
      * @dev Permissionless function to dispatch the current batch. Increments the {currentBatchId}.
-     * Execution will fail if the batch {totalDeposits} is not initialized.
+     * Execution will revert if the batch {totalDeposits} is not initialized.
      *
      * NOTE: Developers should consider adding additional restrictions to this function
      * if maintaining confidentiality of deposits is critical to the application.

--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -90,6 +90,9 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
     /// @dev The `account` has a zero deposits in batch `batchId`.
     error ZeroDeposits(uint256 batchId, address account);
 
+    /// @dev Batch `batchId` has no deposits and cannot be dispatched.
+    error ZeroTotalDeposits(uint256 batchId);
+
     /**
      * @dev The batch `batchId` is in the state `current`, which is invalid for the operation.
      * The `expectedStates` is a bitmap encoding the expected/allowed states for the operation.
@@ -181,14 +184,16 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
 
     /**
      * @dev Permissionless function to dispatch the current batch. Increments the {currentBatchId}.
+     * Execution will fail if the batch {totalDeposits} is not initialized.
      *
      * NOTE: Developers should consider adding additional restrictions to this function
      * if maintaining confidentiality of deposits is critical to the application.
      */
     function dispatchBatch() public virtual {
         uint256 batchId = _getAndIncreaseBatchId();
-
         euint64 amountToUnwrap = totalDeposits(batchId);
+        require(FHE.isInitialized(amountToUnwrap), ZeroTotalDeposits(batchId));
+
         FHE.allowTransient(amountToUnwrap, address(fromToken()));
         _batches[batchId].unwrapRequestId = fromToken().unwrap(
             address(this),

--- a/test/finance/BatcherConfidential.test.ts
+++ b/test/finance/BatcherConfidential.test.ts
@@ -635,6 +635,17 @@ describe('BatcherConfidential', function () {
     it('should emit event', async function () {
       await expect(this.batcher.dispatchBatch()).to.emit(this.batcher, 'BatchDispatched').withArgs(this.batchId);
     });
+
+    it('should revert if total deposits is uninitialized', async function () {
+      await this.batcher.dispatchBatch();
+
+      const newBatchId = await this.batcher.currentBatchId();
+
+      await expect(this.batcher.dispatchBatch())
+        .to.be.revertedWithCustomError(this.batcher, 'ZeroTotalDeposits')
+        .withArgs(newBatchId);
+      await expect(this.batcher.currentBatchId()).to.eventually.eq(newBatchId);
+    });
   });
 
   describe('batch state', async function () {


### PR DESCRIPTION
On design, the intention was to revert on `dispatchBatch` for a batch with uninitialized `totalDepsoits`. Changes to underlying dependancies made it that this no longer holds. In this PR, we add an explicit revert if the `totalDeposits` are unititialized.

Closes #398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Batch dispatching now validates that deposits have been recorded before processing. Attempting to dispatch batches without initialized deposits produces a clear error message, preventing invalid operations and improving system reliability.

* **Tests**
  * Added test coverage to verify that batch dispatch validation correctly rejects uninitialized batches and maintains proper state during failed dispatch attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->