### PR TITLE
Allow redirected BatcherConfidential quit refunds

### DIFF
--- a/.changeset/batcher-quit-recipient.md
+++ b/.changeset/batcher-quit-recipient.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': patch
+---
+
+`BatcherConfidential`: allow callers to redirect `quit` refunds to a recipient address.

--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -159,9 +159,9 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
     }
 
     /**
-     * @dev Quit the batch with id `batchId`. Entire deposit is returned to `recipient`.
+     * @dev Quit the batch with id `batchId`, attempting to return the caller's deposit to `recipient`.
      *
-     * This enables users to redirect their refund if receiving {fromToken} at their own address fails.
+     * If the {fromToken} transfer returns 0, no amount is deducted and the caller can retry with another recipient.
      */
     function quit(uint256 batchId, address recipient) public virtual nonReentrant returns (euint64) {
         return _quit(batchId, msg.sender, recipient);

--- a/contracts/finance/BatcherConfidential.sol
+++ b/contracts/finance/BatcherConfidential.sol
@@ -155,26 +155,43 @@ abstract contract BatcherConfidential is ReentrancyGuardTransient, IERC7984Recei
      * This function must be unrestricted in cases where batch dispatching fails.
      */
     function quit(uint256 batchId) public virtual nonReentrant returns (euint64) {
+        return _quit(batchId, msg.sender, msg.sender);
+    }
+
+    /**
+     * @dev Quit the batch with id `batchId`. Entire deposit is returned to `recipient`.
+     *
+     * This enables users to redirect their refund if receiving {fromToken} at their own address fails.
+     */
+    function quit(uint256 batchId, address recipient) public virtual nonReentrant returns (euint64) {
+        return _quit(batchId, msg.sender, recipient);
+    }
+
+    /**
+     * @dev Internal implementation of {quit}. `account` is the depositor whose balance is reduced, and `recipient`
+     * receives the returned {fromToken}.
+     */
+    function _quit(uint256 batchId, address account, address recipient) internal virtual returns (euint64) {
         _validateStateBitmap(batchId, _encodeStateBitmap(BatchState.Pending) | _encodeStateBitmap(BatchState.Canceled));
 
-        euint64 deposit = deposits(batchId, msg.sender);
-        require(FHE.isInitialized(deposit), ZeroDeposits(batchId, msg.sender));
+        euint64 deposit = deposits(batchId, account);
+        require(FHE.isInitialized(deposit), ZeroDeposits(batchId, account));
 
         euint64 totalDeposits_ = totalDeposits(batchId);
 
         FHE.allowTransient(deposit, address(fromToken()));
-        euint64 sent = fromToken().confidentialTransfer(msg.sender, deposit);
+        euint64 sent = fromToken().confidentialTransfer(recipient, deposit);
         euint64 newTotalDeposits = FHE.sub(totalDeposits_, sent);
         euint64 newDeposit = FHE.sub(deposit, sent);
 
         FHE.allowThis(newTotalDeposits);
         FHE.allowThis(newDeposit);
-        FHE.allow(newDeposit, msg.sender);
+        FHE.allow(newDeposit, account);
 
         _batches[batchId].totalDeposits = newTotalDeposits;
-        _batches[batchId].deposits[msg.sender] = newDeposit;
+        _batches[batchId].deposits[account] = newDeposit;
 
-        emit Quit(batchId, msg.sender, sent);
+        emit Quit(batchId, account, sent);
 
         return sent;
     }

--- a/contracts/mocks/finance/BatcherConfidentialSwapMock.sol
+++ b/contracts/mocks/finance/BatcherConfidentialSwapMock.sol
@@ -66,6 +66,12 @@ abstract contract BatcherConfidentialSwapMock is ZamaEthereumConfig, BatcherConf
         return amount;
     }
 
+    function quit(uint256 batchId, address recipient) public virtual override returns (euint64) {
+        euint64 amount = super.quit(batchId, recipient);
+        FHE.allow(totalDeposits(batchId), admin);
+        return amount;
+    }
+
     function _join(address to, euint64 amount) internal virtual override returns (euint64) {
         euint64 joinedAmount = super._join(to, amount);
         FHE.allow(totalDeposits(currentBatchId()), admin);

--- a/test/finance/BatcherConfidential.test.ts
+++ b/test/finance/BatcherConfidential.test.ts
@@ -502,12 +502,24 @@ describe('BatcherConfidential', function () {
     });
 
     it('should allow retrying a redirected quit if the transfer fails', async function () {
+      const expectTotalDeposits = async (amount: bigint) =>
+        expect(
+          fhevm.userDecryptEuint(
+            FhevmType.euint64,
+            await this.batcher.totalDeposits(this.batchId),
+            this.batcher,
+            this.operator,
+          ),
+        ).to.eventually.eq(amount);
+
       const beforeBalance = await fhevm.userDecryptEuint(
         FhevmType.euint64,
         await this.fromToken.confidentialBalanceOf(this.recipient),
         this.fromToken,
         this.recipient,
       );
+
+      await expectTotalDeposits(this.deposit);
 
       await this.fromToken['$_burn(address,uint64)'](this.batcher, this.deposit);
       await this.batcher.connect(this.holder)['quit(uint256,address)'](this.batchId, this.recipient);
@@ -520,6 +532,7 @@ describe('BatcherConfidential', function () {
           this.holder,
         ),
       ).to.eventually.eq(this.deposit);
+      await expectTotalDeposits(this.deposit);
 
       await this.fromToken['$_mint(address,uint64)'](this.batcher, this.deposit);
       await this.batcher.connect(this.holder)['quit(uint256,address)'](this.batchId, this.recipient);
@@ -541,6 +554,7 @@ describe('BatcherConfidential', function () {
           this.holder,
         ),
       ).to.eventually.eq(0);
+      await expectTotalDeposits(0n);
     });
 
     it('should decrease total deposits', async function () {

--- a/test/finance/BatcherConfidential.test.ts
+++ b/test/finance/BatcherConfidential.test.ts
@@ -472,6 +472,77 @@ describe('BatcherConfidential', function () {
       ).to.eventually.eq(0);
     });
 
+    it('should send refund to the caller selected recipient', async function () {
+      const beforeBalance = await fhevm.userDecryptEuint(
+        FhevmType.euint64,
+        await this.fromToken.confidentialBalanceOf(this.recipient),
+        this.fromToken,
+        this.recipient,
+      );
+
+      await this.batcher.connect(this.holder)['quit(uint256,address)'](this.batchId, this.recipient);
+
+      await expect(
+        fhevm.userDecryptEuint(
+          FhevmType.euint64,
+          await this.fromToken.confidentialBalanceOf(this.recipient),
+          this.fromToken,
+          this.recipient,
+        ),
+      ).to.eventually.eq(beforeBalance + this.deposit);
+
+      await expect(
+        fhevm.userDecryptEuint(
+          FhevmType.euint64,
+          await this.batcher.deposits(this.batchId, this.holder),
+          this.batcher,
+          this.holder,
+        ),
+      ).to.eventually.eq(0);
+    });
+
+    it('should allow retrying a redirected quit if the transfer fails', async function () {
+      const beforeBalance = await fhevm.userDecryptEuint(
+        FhevmType.euint64,
+        await this.fromToken.confidentialBalanceOf(this.recipient),
+        this.fromToken,
+        this.recipient,
+      );
+
+      await this.fromToken['$_burn(address,uint64)'](this.batcher, this.deposit);
+      await this.batcher.connect(this.holder)['quit(uint256,address)'](this.batchId, this.recipient);
+
+      await expect(
+        fhevm.userDecryptEuint(
+          FhevmType.euint64,
+          await this.batcher.deposits(this.batchId, this.holder),
+          this.batcher,
+          this.holder,
+        ),
+      ).to.eventually.eq(this.deposit);
+
+      await this.fromToken['$_mint(address,uint64)'](this.batcher, this.deposit);
+      await this.batcher.connect(this.holder)['quit(uint256,address)'](this.batchId, this.recipient);
+
+      await expect(
+        fhevm.userDecryptEuint(
+          FhevmType.euint64,
+          await this.fromToken.confidentialBalanceOf(this.recipient),
+          this.fromToken,
+          this.recipient,
+        ),
+      ).to.eventually.eq(beforeBalance + this.deposit);
+
+      await expect(
+        fhevm.userDecryptEuint(
+          FhevmType.euint64,
+          await this.batcher.deposits(this.batchId, this.holder),
+          this.batcher,
+          this.holder,
+        ),
+      ).to.eventually.eq(0);
+    });
+
     it('should decrease total deposits', async function () {
       await this.batcher.quit(this.batchId);
 


### PR DESCRIPTION
#### Problem

`BatcherConfidential.quit(uint256)` always refunds to `msg.sender`. If `fromToken.confidentialTransfer(msg.sender, deposit)` fails or returns zero, the caller cannot redirect the refund to another address and the deposit can remain stuck in a pending or canceled batch.

Fixes #370.

#### Summary of Changes

- Keep the existing `quit(uint256)` behavior unchanged.
- Add a `quit(uint256,address)` overload so callers can redirect their own refund.
- Keep failed transfers retryable by only reducing the caller's deposit by the amount actually sent.
- Add regression tests for redirected refunds and failed-transfer retry behavior.
- Add a patch changeset.

#### Testing

- `npx hardhat test test/finance/BatcherConfidential.test.ts`
- `npx hardhat test`
- `npm run lint`
- `forge build`
- `forge lint --deny notes --only-lint unused-import -- contracts/finance/BatcherConfidential.sol contracts/mocks/finance/BatcherConfidentialSwapMock.sol`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended quit functionality to allow redirecting refunds to a specified recipient address, while maintaining backward compatibility with existing operations.

* **Tests**
  * Added test coverage for recipient-directed refunds and error recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->