### PR TITLE
Remove released changesets

### DIFF
--- a/.changeset/chilly-beers-type.md
+++ b/.changeset/chilly-beers-type.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-confidential-contracts': minor
----
-
-`ERC7984Rwa`: Bypass recipient on RWA force transfer in addition to sender.

--- a/.changeset/eager-icons-own.md
+++ b/.changeset/eager-icons-own.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-confidential-contracts': minor
----
-
-`ERC7984Rwa`: block overrides of `Context` functions (`_msgSender()`, `_msgData()`)

--- a/.changeset/eleven-planets-obey.md
+++ b/.changeset/eleven-planets-obey.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-confidential-contracts': patch
----
-
-`BatcherConfidential`: Initialize the zero value before unwrapping when dispatching a batch with no contributions.

--- a/.changeset/few-hotels-scream.md
+++ b/.changeset/few-hotels-scream.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-confidential-contracts': patch
----
-
-`BatcherConfidential`: bug fix. Enable decryption of the `joinedAmount` in `BatcherConfidential`.

--- a/.changeset/tasty-badgers-walk.md
+++ b/.changeset/tasty-badgers-walk.md
@@ -1,5 +1,0 @@
----
-'openzeppelin-confidential-contracts': minor
----
-
-`BatcherConfidential`: revert if underlying `toToken` balance changes during a partial route execution.


### PR DESCRIPTION
Due to a misconfiguration in the release process, some changesets added after kicking off the release process (commits added via cherry-picking) don't get cleaned up. This PR removes changsets that are already associated with a release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch dispatch handling for empty contribution sets, preventing errors when no inputs are provided.
  * Updated transfer behavior so force transfers fully bypass the recipient check in addition to the sender check.
  * Fixed a balance-related issue during partial route execution to avoid unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->