### PR TITLE
Emit `Wrap` event when wrapping on `ERC7984ERC20Wrapper`

### DIFF
--- a/.changeset/purple-spoons-hope.md
+++ b/.changeset/purple-spoons-hope.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': minor
+---
+
+`ERC7984ERC20Wrapper` and `IERC7984ERC20Wrapper`: Emit the `Wrap` event when wrapping tokens.

--- a/contracts/interfaces/IERC7984ERC20Wrapper.sol
+++ b/contracts/interfaces/IERC7984ERC20Wrapper.sol
@@ -8,6 +8,9 @@ import {IERC7984} from "./IERC7984.sol";
 
 /// @dev Interface for ERC7984ERC20Wrapper contract.
 interface IERC7984ERC20Wrapper is IERC7984 {
+    /// @dev Emitted when a wrap request is made for a given `to`, `roundedAmount`, and `encryptedWrappedAmount`.
+    event Wrap(address indexed to, uint256 roundedAmount, euint64 encryptedWrappedAmount);
+
     /// @dev Emitted when an unwrap request is made for a given `receiver`, `unwrapRequestId`, and `amount`.
     event UnwrapRequested(address indexed receiver, bytes32 indexed unwrapRequestId, euint64 amount);
 

--- a/contracts/interfaces/IERC7984ERC20Wrapper.sol
+++ b/contracts/interfaces/IERC7984ERC20Wrapper.sol
@@ -8,8 +8,11 @@ import {IERC7984} from "./IERC7984.sol";
 
 /// @dev Interface for ERC7984ERC20Wrapper contract.
 interface IERC7984ERC20Wrapper is IERC7984 {
-    /// @dev Emitted when a wrap request is made for a given `to`, `roundedAmount`, and `encryptedWrappedAmount`.
-    event Wrap(address indexed to, uint256 roundedAmount, euint64 encryptedWrappedAmount);
+    /**
+     * @dev Emitted when `underlyingAmount` of the underlying token was wrapped into `encryptedWrappedAmount`
+     * confidential tokens and sent to `to`.
+     */
+    event Wrap(address indexed to, uint256 underlyingAmount, euint64 encryptedWrappedAmount);
 
     /// @dev Emitted when an unwrap request is made for a given `receiver`, `unwrapRequestId`, and `amount`.
     event UnwrapRequested(address indexed receiver, bytes32 indexed unwrapRequestId, euint64 amount);

--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -80,10 +80,14 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
      * Returns the amount of wrapped token sent.
      */
     function wrap(address to, uint256 amount) public virtual override returns (euint64) {
-        // take ownership of the tokens
         SafeERC20.safeTransferFrom(IERC20(underlying()), msg.sender, address(this), amount - (amount % rate()));
 
-        return _wrap(to, amount);
+        euint64 wrappedAmount = _wrap(to, amount);
+        if (to != msg.sender) {
+            FHE.allowTransient(wrappedAmount, msg.sender);
+        }
+
+        return wrappedAmount;
     }
 
     /// @dev Unwrap without passing an input proof. See {unwrap-address-address-bytes32-bytes} for more details.

--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -209,11 +209,10 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
      * The `amount` parameter is the amount of underlying tokens to wrap.
      */
     function _wrap(address to, uint256 amount) internal virtual returns (euint64) {
-        // mint confidential token
         euint64 wrappedAmountSent = _mint(to, FHE.asEuint64(SafeCast.toUint64(amount / rate())));
         FHE.allowTransient(wrappedAmountSent, msg.sender);
 
-        emit Wrap(to, amount, wrappedAmountSent);
+        emit Wrap(to, amount - (amount % rate()), wrappedAmountSent);
 
         return wrappedAmountSent;
     }

--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -62,7 +62,7 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
 
         // mint confidential token
         address to = data.length < 20 ? from : address(bytes20(data));
-        _mint(to, FHE.asEuint64(SafeCast.toUint64(amount / rate())));
+        _wrap(to, amount);
 
         // transfer excess back to the sender
         uint256 excess = amount % rate();
@@ -83,11 +83,7 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
         // take ownership of the tokens
         SafeERC20.safeTransferFrom(IERC20(underlying()), msg.sender, address(this), amount - (amount % rate()));
 
-        // mint confidential token
-        euint64 wrappedAmountSent = _mint(to, FHE.asEuint64(SafeCast.toUint64(amount / rate())));
-        FHE.allowTransient(wrappedAmountSent, msg.sender);
-
-        return wrappedAmountSent;
+        return _wrap(to, amount);
     }
 
     /// @dev Unwrap without passing an input proof. See {unwrap-address-address-bytes32-bytes} for more details.
@@ -206,6 +202,20 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
             _checkConfidentialTotalSupply();
         }
         return super._update(from, to, amount);
+    }
+
+    /**
+     * @dev Internal logic for handling wrapping of tokens. Sourcing of the underlying token must be handled by the caller.
+     * The `amount` parameter is the amount of underlying tokens to wrap.
+     */
+    function _wrap(address to, uint256 amount) internal virtual returns (euint64) {
+        // mint confidential token
+        euint64 wrappedAmountSent = _mint(to, FHE.asEuint64(SafeCast.toUint64(amount / rate())));
+        FHE.allowTransient(wrappedAmountSent, msg.sender);
+
+        emit Wrap(to, amount, wrappedAmountSent);
+
+        return wrappedAmountSent;
     }
 
     /// @dev Internal logic for handling the creation of unwrap requests. Returns the unwrap request id.

--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -210,8 +210,6 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
      */
     function _wrap(address to, uint256 amount) internal virtual returns (euint64) {
         euint64 wrappedAmountSent = _mint(to, FHE.asEuint64(SafeCast.toUint64(amount / rate())));
-        FHE.allowTransient(wrappedAmountSent, msg.sender);
-
         emit Wrap(to, amount - (amount % rate()), wrappedAmountSent);
 
         return wrappedAmountSent;

--- a/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
@@ -66,6 +66,26 @@ describe('ERC7984ERC20Wrapper', function () {
           ).to.eventually.equal(10);
         });
 
+        it("wrap event shouldn't be decryptable by sender with different recipient", async function () {
+          const amountToWrap = ethers.parseUnits('100', 18);
+          if (viaCallback) {
+            await this.token
+              .connect(this.holder)
+              ['transferAndCall(address,uint256,bytes)'](
+                this.wrapper,
+                amountToWrap,
+                ethers.solidityPacked(['address'], [this.recipient.address]),
+              );
+          } else {
+            await this.wrapper.connect(this.holder).wrap(this.recipient.address, amountToWrap);
+          }
+
+          const [, , encryptedWrappedAmount] = (await this.wrapper.queryFilter(this.wrapper.filters.Wrap()))[0].args;
+          await expect(
+            fhevm.userDecryptEuint(FhevmType.euint64, encryptedWrappedAmount, this.wrapper.target, this.holder),
+          ).to.be.rejected;
+        });
+
         it('with multiple of rate', async function () {
           const amountToWrap = ethers.parseUnits('100', 18);
 

--- a/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
@@ -67,7 +67,7 @@ describe('ERC7984ERC20Wrapper', function () {
         });
 
         it("wrap event shouldn't be decryptable by sender with different recipient", async function () {
-          const amountToWrap = ethers.parseUnits('100', 18);
+          const amountToWrap = ethers.parseUnits('99', 18);
           if (viaCallback) {
             await this.token
               .connect(this.holder)

--- a/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
@@ -1,6 +1,7 @@
 import { ERC7984ERC20WrapperMock } from '../../../../types';
 import { INTERFACE_IDS, INVALID_ID } from '../../../helpers/interface';
 import { FhevmType } from '@fhevm/hardhat-plugin';
+import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
@@ -47,6 +48,23 @@ describe('ERC7984ERC20Wrapper', function () {
   describe('Wrap', async function () {
     for (const viaCallback of [false, true]) {
       describe(`via ${viaCallback ? 'callback' : 'transfer from'}`, function () {
+        it('emits Wrap event', async function () {
+          const amountToWrap = ethers.parseUnits('100', 18);
+          let call;
+
+          if (viaCallback) {
+            call = this.token.connect(this.holder).transferAndCall(this.wrapper, amountToWrap);
+          } else {
+            call = this.wrapper.connect(this.holder).wrap(this.holder.address, amountToWrap);
+          }
+
+          await expect(call).to.emit(this.wrapper, 'Wrap').withArgs(this.holder.address, amountToWrap, anyValue);
+          const [, , encryptedWrappedAmount] = (await this.wrapper.queryFilter(this.wrapper.filters.Wrap()))[0].args;
+          await expect(
+            fhevm.userDecryptEuint(FhevmType.euint64, encryptedWrappedAmount, this.wrapper.target, this.holder),
+          ).to.eventually.equal(ethers.parseUnits('100', 6));
+        });
+
         it('with multiple of rate', async function () {
           const amountToWrap = ethers.parseUnits('100', 18);
 

--- a/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
@@ -49,20 +49,21 @@ describe('ERC7984ERC20Wrapper', function () {
     for (const viaCallback of [false, true]) {
       describe(`via ${viaCallback ? 'callback' : 'transfer from'}`, function () {
         it('emits Wrap event', async function () {
-          const amountToWrap = ethers.parseUnits('100', 18);
-          let call;
+          const amountToWrap = ethers.parseUnits('101', 11);
+          const roundedAmount = ethers.parseUnits('10', 12);
 
+          let call;
           if (viaCallback) {
             call = this.token.connect(this.holder).transferAndCall(this.wrapper, amountToWrap);
           } else {
             call = this.wrapper.connect(this.holder).wrap(this.holder.address, amountToWrap);
           }
 
-          await expect(call).to.emit(this.wrapper, 'Wrap').withArgs(this.holder.address, amountToWrap, anyValue);
+          await expect(call).to.emit(this.wrapper, 'Wrap').withArgs(this.holder.address, roundedAmount, anyValue);
           const [, , encryptedWrappedAmount] = (await this.wrapper.queryFilter(this.wrapper.filters.Wrap()))[0].args;
           await expect(
             fhevm.userDecryptEuint(FhevmType.euint64, encryptedWrappedAmount, this.wrapper.target, this.holder),
-          ).to.eventually.equal(ethers.parseUnits('100', 6));
+          ).to.eventually.equal(10);
         });
 
         it('with multiple of rate', async function () {


### PR DESCRIPTION
Closes #278

This uses the same `Wrap` event defined in the zama wrapper contract. https://github.com/zama-ai/protocol-apps/blob/3f866a38553e689129c22cbebdf388bf958bba88/contracts/confidential-wrapper/contracts/extensions/ERC7984ERC20WrapperUpgradeable.sol#L42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wrapping tokens now emits a `Wrap` event, including the recipient and wrapped amount.
  * Both direct wrapping and transfer-based wrapping now use the same consistent wrapping flow.

* **Tests**
  * Added coverage to verify the `Wrap` event is emitted correctly for both wrapping methods.
  * Confirmed the wrapped amount matches the expected value after decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->