### PR TITLE
Standardize on "hook manager" terminology for ERC7984 hooks

### DIFF
--- a/.changeset/frank-numbers-kick.md
+++ b/.changeset/frank-numbers-kick.md
@@ -2,4 +2,4 @@
 'openzeppelin-confidential-contracts': minor
 ---
 
-`ERC7984BalanceCapHookModule` and `ERC7984HolderCapHookModule`: Switch configurator authentication from agent check to calling `IERC7984Hooked-isAuthorizedConfigurator` on the token.
+`ERC7984BalanceCapHookModule` and `ERC7984HolderCapHookModule`: Switch hook manager authentication from agent check to calling `IERC7984Hooked-isHookManager` on the token.

--- a/contracts/interfaces/IERC7984Hooked.sol
+++ b/contracts/interfaces/IERC7984Hooked.sol
@@ -27,10 +27,11 @@ interface IERC7984Hooked is IERC7984 {
     function uninstallModule(address module) external;
 
     /**
-     * @dev Returns whether `account` is authorized to configure hook modules installed on this token.
+     * @dev Returns whether `account` is a hook manager, authorized to install, uninstall, and configure
+     * hook modules on this token.
      *
      * Hook modules query this function to gate their configuration entry points. The token is the
-     * source of truth for who may configure its modules.
+     * source of truth for who may manage its hooks.
      */
-    function isAuthorizedConfigurator(address account) external view returns (bool);
+    function isHookManager(address account) external view returns (bool);
 }

--- a/contracts/mocks/token/ERC7984/extensions/ERC7984HookedMock.sol
+++ b/contracts/mocks/token/ERC7984/extensions/ERC7984HookedMock.sol
@@ -20,7 +20,7 @@ contract ERC7984HookedMock is ERC7984Hooked, ERC7984Mock, Ownable {
         return super.supportsInterface(interfaceId);
     }
 
-    function isAuthorizedConfigurator(address account) public view virtual override returns (bool) {
+    function isHookManager(address account) public view virtual override returns (bool) {
         return account == owner();
     }
 

--- a/contracts/token/ERC7984/extensions/ERC7984Hooked.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Hooked.sol
@@ -38,26 +38,26 @@ abstract contract ERC7984Hooked is ERC7984, HandleAccessManager, IERC7984Hooked 
     error ERC7984HookedNonexistentModule(address module);
     /// @dev The maximum number of modules has been exceeded.
     error ERC7984HookedExceededMaxModules();
-    /// @dev The caller is not authorized to change modules.
-    error ERC7984HookedUnauthorizedModuleChange(address caller);
+    /// @dev The caller is not a hook manager.
+    error ERC7984HookedUnauthorizedHookManager(address caller);
 
-    modifier onlyAuthorizedModuleChange() {
-        _checkAuthorizedModuleChange(msg.sender);
+    modifier onlyHookManager() {
+        _checkHookManager(msg.sender);
         _;
     }
 
     /// @inheritdoc IERC7984Hooked
-    function installModule(address module, bytes memory initData) public virtual onlyAuthorizedModuleChange {
+    function installModule(address module, bytes memory initData) public virtual onlyHookManager {
         _installModule(module, initData);
     }
 
     /// @inheritdoc IERC7984Hooked
-    function uninstallModule(address module) public virtual onlyAuthorizedModuleChange {
+    function uninstallModule(address module) public virtual onlyHookManager {
         _uninstallModule(module);
     }
 
     /// @inheritdoc IERC7984Hooked
-    function isAuthorizedConfigurator(address account) public view virtual returns (bool);
+    function isHookManager(address account) public view virtual returns (bool);
 
     /// @inheritdoc IERC7984Hooked
     function isModuleInstalled(address module) public view virtual returns (bool) {
@@ -105,8 +105,8 @@ abstract contract ERC7984Hooked is ERC7984, HandleAccessManager, IERC7984Hooked 
     }
 
     /// @dev Checks if the account is authorized to install and uninstall modules.
-    function _checkAuthorizedModuleChange(address account) internal virtual {
-        require(isAuthorizedConfigurator(account), ERC7984HookedUnauthorizedModuleChange(account));
+    function _checkHookManager(address account) internal virtual {
+        require(isHookManager(account), ERC7984HookedUnauthorizedHookManager(account));
     }
 
     /**

--- a/contracts/token/ERC7984/utils/ERC7984BalanceCapHookModule.sol
+++ b/contracts/token/ERC7984/utils/ERC7984BalanceCapHookModule.sol
@@ -29,13 +29,13 @@ contract ERC7984BalanceCapHookModule is ERC7984HookModule {
     /**
      * @dev Sets the max balance for a given token `token` to the encrypted value `newMaxBalance`.
      *
-     * `msg.sender` must be authorized to configure this module for `token`.
+     * `msg.sender` must be a hook manager for `token`.
      */
     function setMaxBalance(
         address token,
         externalEuint64 newMaxBalance,
         bytes calldata inputProof
-    ) public virtual onlyAuthorizedConfigurator(token) {
+    ) public virtual onlyHookManager(token) {
         _setMaxBalance(token, FHE.fromExternal(newMaxBalance, inputProof));
     }
 

--- a/contracts/token/ERC7984/utils/ERC7984HolderCapHookModule.sol
+++ b/contracts/token/ERC7984/utils/ERC7984HolderCapHookModule.sol
@@ -34,9 +34,9 @@ contract ERC7984HolderCapHookModule is ERC7984HookModule {
     /**
      * @dev Sets the max number of holders for the given token `token` to `maxHolderCount_`.
      *
-     * `msg.sender` must be authorized to configure this module for `token`.
+     * `msg.sender` must be a hook manager for `token`.
      **/
-    function setMaxHolderCount(address token, uint64 maxHolderCount_) public virtual onlyAuthorizedConfigurator(token) {
+    function setMaxHolderCount(address token, uint64 maxHolderCount_) public virtual onlyHookManager(token) {
         _setMaxHolderCount(token, maxHolderCount_);
     }
 

--- a/contracts/token/ERC7984/utils/ERC7984HookModule.sol
+++ b/contracts/token/ERC7984/utils/ERC7984HookModule.sol
@@ -14,14 +14,14 @@ import {HandleAccessManager} from "./../../../utils/HandleAccessManager.sol";
  */
 abstract contract ERC7984HookModule is IERC7984HookModule, ERC165 {
     /// @dev The caller `account` is not authorized to perform the operation.
-    error ERC7984HookModuleUnauthorizedAccount(address account);
+    error ERC7984HookModuleUnauthorizedHookManager(address account);
 
     /// @dev The caller `user` does not have access to the encrypted amount `amount`.
     error ERC7984HookModuleUnauthorizedUseOfEncryptedAmount(euint64 amount, address user);
 
-    /// @dev Restricts access to token accounts authorized to configure the module.
-    modifier onlyAuthorizedConfigurator(address token) {
-        _checkAuthorizedConfigurator(token, msg.sender);
+    /// @dev Restricts access to the token's hook manager(s).
+    modifier onlyHookManager(address token) {
+        _checkHookManager(token, msg.sender);
         _;
     }
 
@@ -56,12 +56,12 @@ abstract contract ERC7984HookModule is IERC7984HookModule, ERC165 {
     }
 
     /**
-     * @dev Verifies that `account` is authorized to configure this module for `token`. Defers to the
-     * token, which is the source of truth for who may configure its modules, via
-     * {IERC7984Hooked-isAuthorizedConfigurator}.
+     * @dev Verifies that `account` is a hook manager for `token`. Defers to the
+     * token, which is the source of truth for who may manage its hooks, via
+     * {IERC7984Hooked-isHookManager}.
      */
-    function _checkAuthorizedConfigurator(address token, address account) internal view virtual {
-        require(IERC7984Hooked(token).isAuthorizedConfigurator(account), ERC7984HookModuleUnauthorizedAccount(account));
+    function _checkHookManager(address token, address account) internal view virtual {
+        require(IERC7984Hooked(token).isHookManager(account), ERC7984HookModuleUnauthorizedHookManager(account));
     }
 
     /**

--- a/test/helpers/interface.ts
+++ b/test/helpers/interface.ts
@@ -60,7 +60,7 @@ export const SIGNATURES = {
     'isModuleInstalled(address)',
     'installModule(address,bytes)',
     'uninstallModule(address)',
-    'isAuthorizedConfigurator(address)',
+    'isHookManager(address)',
   ],
 };
 

--- a/test/token/ERC7984/extensions/ERC7984Hooked.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984Hooked.test.ts
@@ -54,7 +54,7 @@ describe('ERC7984Hooked', function () {
       await expect(this.token.modules(0, ethers.MaxInt256)).to.eventually.deep.equal([this.hookModule.target]);
     });
 
-    it('should gate via `_authorizeModuleChange`', async function () {
+    it('should gate via `_checkHookManager`', async function () {
       await expect(this.token.connect(this.anyone).installModule(this.hookModule, '0x'))
         .to.be.revertedWithCustomError(this.token, 'ERC7984HookedUnauthorizedHookManager')
         .withArgs(this.anyone);
@@ -116,7 +116,7 @@ describe('ERC7984Hooked', function () {
       await expect(this.token.isModuleInstalled(this.hookModule)).to.eventually.be.false;
     });
 
-    it('should gate via `_authorizeModuleChange`', async function () {
+    it('should gate via `_checkHookManager`', async function () {
       await expect(this.token.connect(this.anyone).uninstallModule(this.hookModule))
         .to.be.revertedWithCustomError(this.token, 'ERC7984HookedUnauthorizedHookManager')
         .withArgs(this.anyone);

--- a/test/token/ERC7984/extensions/ERC7984Hooked.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984Hooked.test.ts
@@ -56,7 +56,7 @@ describe('ERC7984Hooked', function () {
 
     it('should gate via `_authorizeModuleChange`', async function () {
       await expect(this.token.connect(this.anyone).installModule(this.hookModule, '0x'))
-        .to.be.revertedWithCustomError(this.token, 'ERC7984HookedUnauthorizedModuleChange')
+        .to.be.revertedWithCustomError(this.token, 'ERC7984HookedUnauthorizedHookManager')
         .withArgs(this.anyone);
 
       await this.token.connect(this.admin).installModule(this.hookModule, '0x');
@@ -118,7 +118,7 @@ describe('ERC7984Hooked', function () {
 
     it('should gate via `_authorizeModuleChange`', async function () {
       await expect(this.token.connect(this.anyone).uninstallModule(this.hookModule))
-        .to.be.revertedWithCustomError(this.token, 'ERC7984HookedUnauthorizedModuleChange')
+        .to.be.revertedWithCustomError(this.token, 'ERC7984HookedUnauthorizedHookManager')
         .withArgs(this.anyone);
 
       await this.token.connect(this.admin).uninstallModule(this.hookModule);
@@ -157,14 +157,14 @@ describe('ERC7984Hooked', function () {
     }
   });
 
-  describe('isAuthorizedConfigurator', async function () {
-    it('should authorize the configurator (mock gates by ownable)', async function () {
-      await expect(this.token.isAuthorizedConfigurator(this.admin)).to.eventually.be.true;
+  describe('isHookManager', async function () {
+    it('should authorize the hook manager (mock gates by ownable)', async function () {
+      await expect(this.token.isHookManager(this.admin)).to.eventually.be.true;
     });
 
-    it('should not authorize a non-configurator', async function () {
-      await expect(this.token.isAuthorizedConfigurator(this.anyone)).to.eventually.be.false;
-      await expect(this.token.isAuthorizedConfigurator(this.holder)).to.eventually.be.false;
+    it('should not authorize a non-hook-manager', async function () {
+      await expect(this.token.isHookManager(this.anyone)).to.eventually.be.false;
+      await expect(this.token.isHookManager(this.holder)).to.eventually.be.false;
     });
   });
 });

--- a/test/token/ERC7984/utils/ERC7984BalanceCapHookModule.test.ts
+++ b/test/token/ERC7984/utils/ERC7984BalanceCapHookModule.test.ts
@@ -6,7 +6,7 @@ import { ethers, fhevm } from 'hardhat';
 describe('ERC7984BalanceCapHookModule', function () {
   beforeEach(async function () {
     const [anyone, admin, holder, recipient] = await ethers.getSigners();
-    // The token's `isAuthorizedConfigurator` (mock) gates module configuration to the owner (`admin`).
+    // The token's `isHookManager` (mock) gates module configuration to the owner (`admin`).
     const token = (await ethers.deployContract('$ERC7984HookedMock', ['name', 'symbol', 'uri', admin])) as any;
     const complianceModule = (await ethers.deployContract('$ERC7984BalanceCapHookModuleMock')) as any;
 
@@ -168,10 +168,10 @@ describe('ERC7984BalanceCapHookModule', function () {
   });
 
   describe('setMaxBalance', function () {
-    it('should be gated to the authorized configurator', async function () {
+    it('should be gated to the hook manager', async function () {
       const enc = await this.encryptCap(this.anyone, 100);
       await expect(this.complianceModule.connect(this.anyone).setMaxBalance(this.token, enc.handles[0], enc.inputProof))
-        .to.be.revertedWithCustomError(this.complianceModule, 'ERC7984HookModuleUnauthorizedAccount')
+        .to.be.revertedWithCustomError(this.complianceModule, 'ERC7984HookModuleUnauthorizedHookManager')
         .withArgs(this.anyone);
     });
 

--- a/test/token/ERC7984/utils/ERC7984HolderCapHookModules.test.ts
+++ b/test/token/ERC7984/utils/ERC7984HolderCapHookModules.test.ts
@@ -5,7 +5,7 @@ import { ethers, fhevm } from 'hardhat';
 describe('ERC7984HolderCapHookModules', function () {
   beforeEach(async function () {
     const [anyone, admin, holder, recipient, ...others] = await ethers.getSigners();
-    // The token's `isAuthorizedConfigurator` (mock) gates module configuration to the owner (`admin`).
+    // The token's `isHookManager` (mock) gates module configuration to the owner (`admin`).
     const token = (await ethers.deployContract('$ERC7984HookedMock', ['name', 'symbol', 'uri', admin])) as any;
     const complianceModule = await ethers.deployContract('$ERC7984HolderCapHookModuleMock', [admin]);
 
@@ -40,9 +40,9 @@ describe('ERC7984HolderCapHookModules', function () {
         .withArgs(this.token, 20);
     });
 
-    it('should be gated to the authorized configurator', async function () {
+    it('should be gated to the hook manager', async function () {
       await expect(this.complianceModule.connect(this.anyone).setMaxHolderCount(this.token, 20))
-        .to.be.revertedWithCustomError(this.complianceModule, 'ERC7984HookModuleUnauthorizedAccount')
+        .to.be.revertedWithCustomError(this.complianceModule, 'ERC7984HookModuleUnauthorizedHookManager')
         .withArgs(this.anyone);
     });
   });


### PR DESCRIPTION
Unify the two inconsistent naming families for the account authorized to install, uninstall, and configure hook modules ("Configurator" and "ModuleChange") onto a single term: hook manager.

Token side (IERC7984Hooked / ERC7984Hooked):
- isAuthorizedConfigurator -> isHookManager
- onlyAuthorizedModuleChange -> onlyHookManager
- _checkAuthorizedModuleChange -> _checkHookManager
- ERC7984HookedUnauthorizedModuleChange -> ERC7984HookedUnauthorizedHookManager

Module side (ERC7984HookModule):
- onlyAuthorizedConfigurator -> onlyHookManager
- _checkAuthorizedConfigurator -> _checkHookManager
- ERC7984HookModuleUnauthorizedAccount -> ERC7984HookModuleUnauthorizedHookManager

Pure rename plus natspec/comment alignment; no behavioral change.