### PR TITLE
Track unminted amounts in `ERC7984ERC20Wrapper`

### DIFF
--- a/.changeset/twelve-lamps-jump.md
+++ b/.changeset/twelve-lamps-jump.md
@@ -2,4 +2,4 @@
 'openzeppelin-confidential-contracts': minor
 ---
 
-`ERC7984ERC20Wrapper`: Track amounts that were paid for but not minted when `_update` caps the confidential total supply, and let holders redeem them through `unwrap` (consumed before burning any confidential balance).
+`ERC7984ERC20Wrapper`: Track amounts that were paid for but not minted when `_update` caps the confidential total supply, and let holders redeem them through `unwrap` (consumed before burning any confidential balance). The unminted amount of a holder can be read with the new `unmintedAmountOf` getter.

--- a/.changeset/twelve-lamps-jump.md
+++ b/.changeset/twelve-lamps-jump.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': minor
+---
+
+`ERC7984ERC20Wrapper`: Track amounts that were paid for but not minted when `_update` caps the confidential total supply, and let holders redeem them through `unwrap` (consumed before burning any confidential balance).

--- a/contracts/mocks/token/ERC7984/extensions/ERC7984ERC20WrapperUncheckedSupplyMock.sol
+++ b/contracts/mocks/token/ERC7984/extensions/ERC7984ERC20WrapperUncheckedSupplyMock.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import {ERC7984ERC20WrapperMock} from "./ERC7984ERC20WrapperMock.sol";
+
+/**
+ * @dev Wrapper mock that disables the synchronous total-supply overflow check, so `_update` silently caps the minted
+ * amount (returning less than requested) instead of reverting. This makes the unminted-amount bookkeeping observable.
+ */
+contract ERC7984ERC20WrapperUncheckedSupplyMock is ERC7984ERC20WrapperMock {
+    constructor(
+        IERC20 token,
+        string memory name,
+        string memory symbol,
+        string memory uri
+    ) ERC7984ERC20WrapperMock(token, name, symbol, uri) {}
+
+    function _checkConfidentialTotalSupply() internal override {}
+}

--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -270,13 +270,8 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
         return FHE.add(consumedAmount, burnedAmount);
     }
 
-    /**
-     * @inheritdoc ERC7984
-     * @dev On mint (`from == address(0)`), {_checkConfidentialTotalSupply} is invoked before the update to reject (by
-     * default) any wrap that would exceed {maxTotalSupply}. Recording the unminted amount when a derived contract
-     * lets {_mint} cap silently is handled by {_mintOrIncreaseUnmintedAmount}. See {_unmintedAmounts}.
-     */
-    function _update(address from, address to, euint64 amount) internal virtual override returns (euint64 transferred) {
+    /// @inheritdoc ERC7984
+    function _update(address from, address to, euint64 amount) internal virtual override returns (euint64) {
         if (from == address(0)) {
             _checkConfidentialTotalSupply();
         }

--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -32,8 +32,8 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
     /**
      * @dev Per-holder amount that was paid for (i.e. the underlying was pulled into the wrapper) but that {_mint}
      * did not actually mint because doing so would have exceeded the {maxTotalSupply}. These amounts are not reflected
-     * in {confidentialBalanceOf} but remain redeemable by the holder through {unwrap}, which consumes them before
-     * burning any confidential balance. See {_update} for details.
+     * in {confidentialBalanceOf} (they can be read with {unmintedAmountOf}) but remain redeemable by the holder through
+     * {unwrap}, which consumes them before burning any confidential balance. See {_update} for details.
      *
      * NOTE: With the default {_checkConfidentialTotalSupply}, wrapping reverts on overflow, so no unminted amount is
      * ever recorded. This bookkeeping only becomes relevant for derived contracts whose overflow handling lets {_mint}
@@ -197,6 +197,16 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
      */
     function unwrapRequester(bytes32 unwrapRequestId) public view virtual returns (address) {
         return _unwrapRequests[unwrapRequestId];
+    }
+
+    /**
+     * @dev Returns the encrypted amount that `holder` paid for but that was not minted because {_update} capped the
+     * confidential total supply. This amount is redeemable through {unwrap}. See {_unmintedAmounts}.
+     *
+     * NOTE: Returns an uninitialized handle (decrypting to 0) for a `holder` that never had an unminted amount recorded.
+     */
+    function unmintedAmountOf(address holder) public view virtual returns (euint64) {
+        return _unmintedAmounts[holder];
     }
 
     /**

--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -33,7 +33,8 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
      * @dev Per-holder amount that was paid for (i.e. the underlying was pulled into the wrapper) but that {_mint}
      * did not actually mint because doing so would have exceeded the {maxTotalSupply}. These amounts are not reflected
      * in {confidentialBalanceOf} (they can be read with {unmintedAmountOf}) but remain redeemable by the holder through
-     * {unwrap}, which consumes them before burning any confidential balance. See {_update} for details.
+     * {unwrap}, which consumes them before burning any confidential balance. See {_mintOrIncreaseUnmintedAmount} and
+     * {_burnOrDecreaseUnmintedAmount} for details.
      *
      * NOTE: With the default {_checkConfidentialTotalSupply}, wrapping reverts on overflow, so no unminted amount is
      * ever recorded. This bookkeeping only becomes relevant for derived contracts whose overflow handling lets {_mint}
@@ -74,7 +75,7 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
 
         // mint confidential token
         address to = data.length < 20 ? from : address(bytes20(data));
-        _mint(to, FHE.asEuint64(SafeCast.toUint64(amount / rate())));
+        _mintOrIncreaseUnmintedAmount(to, FHE.asEuint64(SafeCast.toUint64(amount / rate())));
 
         // transfer excess back to the sender
         uint256 excess = amount % rate();
@@ -96,7 +97,10 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
         SafeERC20.safeTransferFrom(IERC20(underlying()), msg.sender, address(this), amount - (amount % rate()));
 
         // mint confidential token
-        euint64 wrappedAmountSent = _mint(to, FHE.asEuint64(SafeCast.toUint64(amount / rate())));
+        euint64 wrappedAmountSent = _mintOrIncreaseUnmintedAmount(
+            to,
+            FHE.asEuint64(SafeCast.toUint64(amount / rate()))
+        );
         FHE.allowTransient(wrappedAmountSent, msg.sender);
 
         return wrappedAmountSent;
@@ -223,19 +227,60 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
     }
 
     /**
+     * @dev Mints up to `amount` confidential tokens to `to` and records any shortfall as an unminted amount. Returns
+     * the amount actually minted.
+     *
+     * When {_mint} caps the minted amount (because minting the full `amount` would exceed {maxTotalSupply}), the
+     * difference is added to the unminted balance of `to`, so the underlying tokens already pulled into the wrapper
+     * remain redeemable through {unwrap}. See {_unmintedAmounts}.
+     */
+    function _mintOrIncreaseUnmintedAmount(address to, euint64 amount) internal virtual returns (euint64) {
+        // mint
+        euint64 mintedAmount = _mint(to, amount);
+
+        // missing
+        euint64 missingAmount = FHE.sub(amount, mintedAmount);
+
+        // update unminted amount
+        euint64 current = _unmintedAmounts[to];
+        euint64 newUnmintedAmount = FHE.add(current, missingAmount);
+        _unmintedAmounts[to] = newUnmintedAmount;
+        FHE.allowThis(newUnmintedAmount);
+        FHE.allow(newUnmintedAmount, to);
+
+        return mintedAmount;
+    }
+
+    /**
+     * @dev Redeems up to `amount` from `from`, consuming the unminted balance first and burning the remainder from the
+     * confidential balance. Returns the total amount redeemed (consumed plus burned).
+     *
+     * Consuming the unminted balance first ensures the underlying tokens that were pulled in but never minted (see
+     * {_unmintedAmounts}) are released before any confidential balance is burned.
+     */
+    function _burnOrDecreaseUnmintedAmount(address from, euint64 amount) internal virtual returns (euint64) {
+        euint64 current = _unmintedAmounts[from];
+        euint64 consumedAmount = FHE.min(current, amount);
+        euint64 newUnmintedAmount = FHE.sub(current, consumedAmount);
+        _unmintedAmounts[from] = newUnmintedAmount;
+        FHE.allowThis(newUnmintedAmount);
+        FHE.allow(newUnmintedAmount, from);
+
+        euint64 burnedAmount = _burn(from, FHE.sub(amount, consumedAmount));
+        return FHE.add(consumedAmount, burnedAmount);
+    }
+
+    /**
      * @inheritdoc ERC7984
-     * @dev On mint (`from == address(0)`), the difference between the requested `amount` and the amount actually
-     * minted by {ERC7984-_update} (which caps at {maxTotalSupply}) is registered as an unminted amount for `to`, so
-     * the underlying tokens already pulled into the wrapper remain redeemable through {unwrap}. See {_unmintedAmounts}.
+     * @dev On mint (`from == address(0)`), {_checkConfidentialTotalSupply} is invoked before the update to reject (by
+     * default) any wrap that would exceed {maxTotalSupply}. Recording the unminted amount when a derived contract
+     * lets {_mint} cap silently is handled by {_mintOrIncreaseUnmintedAmount}. See {_unmintedAmounts}.
      */
     function _update(address from, address to, euint64 amount) internal virtual override returns (euint64 transferred) {
         if (from == address(0)) {
             _checkConfidentialTotalSupply();
         }
-        transferred = super._update(from, to, amount);
-        if (from == address(0)) {
-            _increaseUnmintedAmount(to, FHE.sub(amount, transferred));
-        }
+        return super._update(from, to, amount);
     }
 
     /// @dev Internal logic for handling the creation of unwrap requests. Returns the unwrap request id.
@@ -244,9 +289,7 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
         require(from == msg.sender || isOperator(from, msg.sender), ERC7984UnauthorizedSpender(from, msg.sender));
 
         // Consume from unminted amounts first, then burn the rest, and see how much we actually got
-        euint64 fromUnmintedAmount = _decreaseUnmintedAmount(from, amount);
-        euint64 fromBurnedAmount = _burn(from, FHE.sub(amount, fromUnmintedAmount));
-        euint64 unwrapAmount_ = FHE.add(fromUnmintedAmount, fromBurnedAmount);
+        euint64 unwrapAmount_ = _burnOrDecreaseUnmintedAmount(from, amount);
 
         FHE.makePubliclyDecryptable(unwrapAmount_);
 
@@ -260,42 +303,6 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
 
         emit UnwrapRequested(to, unwrapRequestId, unwrapAmount_);
         return unwrapRequestId;
-    }
-
-    /**
-     * @dev Adds `amount` to the unminted balance of `holder`. See {_unmintedAmounts}.
-     *
-     * When `amount` is uninitialized there is nothing to record, and when `holder` has no prior unminted balance the
-     * stored handle is set directly to `amount`. Both cases skip the {FHE-add}, so no homomorphic work is done in the
-     * common case where nothing was left unminted.
-     */
-    function _increaseUnmintedAmount(address holder, euint64 amount) internal virtual {
-        if (!FHE.isInitialized(amount)) return;
-
-        euint64 current = _unmintedAmounts[holder];
-        euint64 unmintedAmount = FHE.isInitialized(current) ? FHE.add(current, amount) : amount;
-        _unmintedAmounts[holder] = unmintedAmount;
-        FHE.allowThis(unmintedAmount);
-        FHE.allow(unmintedAmount, holder);
-    }
-
-    /**
-     * @dev Consumes up to `amount` from the unminted balance of `holder` and returns the consumed amount. See
-     * {_unmintedAmounts}.
-     *
-     * When `holder` has no unminted balance the function returns an encrypted zero without any homomorphic work, which
-     * is the common case (e.g. an account that received its confidential tokens through a transfer rather than {wrap}).
-     */
-    function _decreaseUnmintedAmount(address holder, euint64 amount) internal virtual returns (euint64) {
-        euint64 unmintedAmount = _unmintedAmounts[holder];
-        if (!FHE.isInitialized(unmintedAmount)) return FHE.asEuint64(0);
-
-        euint64 consumedAmount = FHE.min(unmintedAmount, amount);
-        unmintedAmount = FHE.sub(unmintedAmount, consumedAmount);
-        _unmintedAmounts[holder] = unmintedAmount;
-        FHE.allowThis(unmintedAmount);
-        FHE.allow(unmintedAmount, holder);
-        return consumedAmount;
     }
 
     /**

--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -29,6 +29,18 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
 
     mapping(bytes32 unwrapRequestId => address recipient) private _unwrapRequests;
 
+    /**
+     * @dev Per-holder amount that was paid for (i.e. the underlying was pulled into the wrapper) but that {_mint}
+     * did not actually mint because doing so would have exceeded the {maxTotalSupply}. These amounts are not reflected
+     * in {confidentialBalanceOf} but remain redeemable by the holder through {unwrap}, which consumes them before
+     * burning any confidential balance. See {_update} for details.
+     *
+     * NOTE: With the default {_checkConfidentialTotalSupply}, wrapping reverts on overflow, so no unminted amount is
+     * ever recorded. This bookkeeping only becomes relevant for derived contracts whose overflow handling lets {_mint}
+     * silently cap the minted amount instead of reverting.
+     */
+    mapping(address holder => euint64 amount) private _unmintedAmounts;
+
     error InvalidUnwrapRequest(bytes32 unwrapRequestId);
     error ERC7984TotalSupplyOverflow();
 
@@ -200,12 +212,20 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
         }
     }
 
-    /// @inheritdoc ERC7984
-    function _update(address from, address to, euint64 amount) internal virtual override returns (euint64) {
+    /**
+     * @inheritdoc ERC7984
+     * @dev On mint (`from == address(0)`), the difference between the requested `amount` and the amount actually
+     * minted by {ERC7984-_update} (which caps at {maxTotalSupply}) is registered as an unminted amount for `to`, so
+     * the underlying tokens already pulled into the wrapper remain redeemable through {unwrap}. See {_unmintedAmounts}.
+     */
+    function _update(address from, address to, euint64 amount) internal virtual override returns (euint64 transferred) {
         if (from == address(0)) {
             _checkConfidentialTotalSupply();
         }
-        return super._update(from, to, amount);
+        transferred = super._update(from, to, amount);
+        if (from == address(0)) {
+            _increaseUnmintedAmount(to, FHE.sub(amount, transferred));
+        }
     }
 
     /// @dev Internal logic for handling the creation of unwrap requests. Returns the unwrap request id.
@@ -213,8 +233,11 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
         require(to != address(0), ERC7984InvalidReceiver(to));
         require(from == msg.sender || isOperator(from, msg.sender), ERC7984UnauthorizedSpender(from, msg.sender));
 
-        // try to burn, see how much we actually got
-        euint64 unwrapAmount_ = _burn(from, amount);
+        // Consume from unminted amounts first, then burn the rest, and see how much we actually got
+        euint64 fromUnmintedAmount = _decreaseUnmintedAmount(from, amount);
+        euint64 fromBurnedAmount = _burn(from, FHE.sub(amount, fromUnmintedAmount));
+        euint64 unwrapAmount_ = FHE.add(fromUnmintedAmount, fromBurnedAmount);
+
         FHE.makePubliclyDecryptable(unwrapAmount_);
 
         assert(unwrapRequester(euint64.unwrap(unwrapAmount_)) == address(0));
@@ -227,6 +250,42 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
 
         emit UnwrapRequested(to, unwrapRequestId, unwrapAmount_);
         return unwrapRequestId;
+    }
+
+    /**
+     * @dev Adds `amount` to the unminted balance of `holder`. See {_unmintedAmounts}.
+     *
+     * When `amount` is uninitialized there is nothing to record, and when `holder` has no prior unminted balance the
+     * stored handle is set directly to `amount`. Both cases skip the {FHE-add}, so no homomorphic work is done in the
+     * common case where nothing was left unminted.
+     */
+    function _increaseUnmintedAmount(address holder, euint64 amount) internal virtual {
+        if (!FHE.isInitialized(amount)) return;
+
+        euint64 current = _unmintedAmounts[holder];
+        euint64 unmintedAmount = FHE.isInitialized(current) ? FHE.add(current, amount) : amount;
+        _unmintedAmounts[holder] = unmintedAmount;
+        FHE.allowThis(unmintedAmount);
+        FHE.allow(unmintedAmount, holder);
+    }
+
+    /**
+     * @dev Consumes up to `amount` from the unminted balance of `holder` and returns the consumed amount. See
+     * {_unmintedAmounts}.
+     *
+     * When `holder` has no unminted balance the function returns an encrypted zero without any homomorphic work, which
+     * is the common case (e.g. an account that received its confidential tokens through a transfer rather than {wrap}).
+     */
+    function _decreaseUnmintedAmount(address holder, euint64 amount) internal virtual returns (euint64) {
+        euint64 unmintedAmount = _unmintedAmounts[holder];
+        if (!FHE.isInitialized(unmintedAmount)) return FHE.asEuint64(0);
+
+        euint64 consumedAmount = FHE.min(unmintedAmount, amount);
+        unmintedAmount = FHE.sub(unmintedAmount, consumedAmount);
+        _unmintedAmounts[holder] = unmintedAmount;
+        FHE.allowThis(unmintedAmount);
+        FHE.allow(unmintedAmount, holder);
+        return consumedAmount;
     }
 
     /**

--- a/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
@@ -342,6 +342,110 @@ describe('ERC7984ERC20Wrapper', function () {
     });
   });
 
+  describe('Unminted amounts', function () {
+    // 18-decimal underlying => rate is 10 ** (18 - 6)
+    const rate = 10n ** 12n;
+    const maxConfidentialSupply = 2n ** 64n - 1n;
+
+    beforeEach(async function () {
+      // Wrapper whose `_checkConfidentialTotalSupply` is a no-op, so `_update` silently caps the minted amount
+      // instead of reverting on overflow. This is what makes an unminted amount observable.
+      this.wrapper = await ethers.deployContract('$ERC7984ERC20WrapperUncheckedSupplyMock', [
+        this.token,
+        name,
+        symbol,
+        uri,
+      ]);
+
+      // Fund the holder with enough underlying to fill the confidential supply up to its maximum (plus some extra)
+      await this.token.$_mint(this.holder.address, (maxConfidentialSupply + 1000n) * rate);
+      await this.token.connect(this.holder).approve(this.wrapper, ethers.MaxUint256);
+
+      // Bring the confidential total supply up to its maximum
+      await this.wrapper.connect(this.holder).wrap(this.holder.address, maxConfidentialSupply * rate);
+    });
+
+    it('records the capped amount as unminted and keeps it redeemable', async function () {
+      const unminted = 100n;
+      const wrapperUnderlyingBefore = await this.token.balanceOf(this.wrapper);
+
+      // Wrapping again overflows the confidential supply: nothing is minted, but the underlying is still pulled in
+      await this.wrapper.connect(this.holder).wrap(this.holder.address, unminted * rate);
+
+      // The confidential balance is unchanged (the mint was capped) ...
+      await expect(
+        fhevm.userDecryptEuint(
+          FhevmType.euint64,
+          await this.wrapper.confidentialBalanceOf(this.holder.address),
+          this.wrapper.target,
+          this.holder,
+        ),
+      ).to.eventually.equal(maxConfidentialSupply);
+      // ... but the underlying was transferred into the wrapper
+      await expect(this.token.balanceOf(this.wrapper)).to.eventually.equal(wrapperUnderlyingBefore + unminted * rate);
+
+      // The holder can recover the unminted amount through `unwrap` without touching their confidential balance
+      const holderUnderlyingBefore = await this.token.balanceOf(this.holder);
+      const encryptedInput = await fhevm
+        .createEncryptedInput(this.wrapper.target, this.holder.address)
+        .add64(unminted)
+        .encrypt();
+      await this.wrapper
+        .connect(this.holder)
+        ['unwrap(address,address,bytes32,bytes)'](
+          this.holder,
+          this.holder,
+          encryptedInput.handles[0],
+          encryptedInput.inputProof,
+        );
+      await publicDecryptAndFinalizeUnwrap(this.wrapper, this.holder);
+
+      await expect(this.token.balanceOf(this.holder)).to.eventually.equal(holderUnderlyingBefore + unminted * rate);
+      await expect(
+        fhevm.userDecryptEuint(
+          FhevmType.euint64,
+          await this.wrapper.confidentialBalanceOf(this.holder.address),
+          this.wrapper.target,
+          this.holder,
+        ),
+      ).to.eventually.equal(maxConfidentialSupply);
+    });
+
+    it('consumes the unminted amount before burning the confidential balance', async function () {
+      const unminted = 50n;
+      await this.wrapper.connect(this.holder).wrap(this.holder.address, unminted * rate);
+
+      // Unwrap more than the unminted amount: the excess is burned from the confidential balance
+      const unwrapAmount = 80n;
+      const holderUnderlyingBefore = await this.token.balanceOf(this.holder);
+      const encryptedInput = await fhevm
+        .createEncryptedInput(this.wrapper.target, this.holder.address)
+        .add64(unwrapAmount)
+        .encrypt();
+      await this.wrapper
+        .connect(this.holder)
+        ['unwrap(address,address,bytes32,bytes)'](
+          this.holder,
+          this.holder,
+          encryptedInput.handles[0],
+          encryptedInput.inputProof,
+        );
+      await publicDecryptAndFinalizeUnwrap(this.wrapper, this.holder);
+
+      // The full requested amount is returned ...
+      await expect(this.token.balanceOf(this.holder)).to.eventually.equal(holderUnderlyingBefore + unwrapAmount * rate);
+      // ... and only the part exceeding the unminted amount was burned from the confidential balance
+      await expect(
+        fhevm.userDecryptEuint(
+          FhevmType.euint64,
+          await this.wrapper.confidentialBalanceOf(this.holder.address),
+          this.wrapper.target,
+          this.holder,
+        ),
+      ).to.eventually.equal(maxConfidentialSupply - (unwrapAmount - unminted));
+    });
+  });
+
   describe('Initialization', function () {
     describe('decimals', function () {
       it('when underlying has 6 decimals', async function () {

--- a/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
@@ -381,6 +381,15 @@ describe('ERC7984ERC20Wrapper', function () {
           this.holder,
         ),
       ).to.eventually.equal(maxConfidentialSupply);
+      // ... the capped amount is recorded as unminted ...
+      await expect(
+        fhevm.userDecryptEuint(
+          FhevmType.euint64,
+          await this.wrapper.unmintedAmountOf(this.holder.address),
+          this.wrapper.target,
+          this.holder,
+        ),
+      ).to.eventually.equal(unminted);
       // ... but the underlying was transferred into the wrapper
       await expect(this.token.balanceOf(this.wrapper)).to.eventually.equal(wrapperUnderlyingBefore + unminted * rate);
 
@@ -409,11 +418,28 @@ describe('ERC7984ERC20Wrapper', function () {
           this.holder,
         ),
       ).to.eventually.equal(maxConfidentialSupply);
+      // the unminted amount has been fully consumed
+      await expect(
+        fhevm.userDecryptEuint(
+          FhevmType.euint64,
+          await this.wrapper.unmintedAmountOf(this.holder.address),
+          this.wrapper.target,
+          this.holder,
+        ),
+      ).to.eventually.equal(0);
     });
 
     it('consumes the unminted amount before burning the confidential balance', async function () {
       const unminted = 50n;
       await this.wrapper.connect(this.holder).wrap(this.holder.address, unminted * rate);
+      await expect(
+        fhevm.userDecryptEuint(
+          FhevmType.euint64,
+          await this.wrapper.unmintedAmountOf(this.holder.address),
+          this.wrapper.target,
+          this.holder,
+        ),
+      ).to.eventually.equal(unminted);
 
       // Unwrap more than the unminted amount: the excess is burned from the confidential balance
       const unwrapAmount = 80n;
@@ -434,7 +460,7 @@ describe('ERC7984ERC20Wrapper', function () {
 
       // The full requested amount is returned ...
       await expect(this.token.balanceOf(this.holder)).to.eventually.equal(holderUnderlyingBefore + unwrapAmount * rate);
-      // ... and only the part exceeding the unminted amount was burned from the confidential balance
+      // ... only the part exceeding the unminted amount was burned from the confidential balance ...
       await expect(
         fhevm.userDecryptEuint(
           FhevmType.euint64,
@@ -443,6 +469,15 @@ describe('ERC7984ERC20Wrapper', function () {
           this.holder,
         ),
       ).to.eventually.equal(maxConfidentialSupply - (unwrapAmount - unminted));
+      // ... and the unminted amount has been fully consumed
+      await expect(
+        fhevm.userDecryptEuint(
+          FhevmType.euint64,
+          await this.wrapper.unmintedAmountOf(this.holder.address),
+          this.wrapper.target,
+          this.holder,
+        ),
+      ).to.eventually.equal(0);
     });
   });
 


### PR DESCRIPTION
## Motivation

When minting in `ERC7984ERC20Wrapper`, `ERC7984._update` (via `FHESafeMath.tryIncrease`) can mint *less* than requested — it caps at `maxTotalSupply` and returns `transferred = 0` on overflow rather than reverting. In that situation the underlying tokens have already been pulled into the wrapper, so the depositor would have paid for tokens they never received and could not recover.

## Changes

- Track, per holder, the paid-for-but-unminted difference in a new `_unmintedAmounts` mapping.
- Registration happens in the `_update` override, so every mint path (`wrap`, `onTransferReceived`, and `_mint` in derived contracts) is covered.
- `unwrap` consumes a holder's unminted balance first, then burns the remainder from their confidential balance, so those underlying tokens remain redeemable.
- The `_increaseUnmintedAmount` / `_decreaseUnmintedAmount` helpers use `FHE.isInitialized` guards to skip all homomorphic work in the common case where a holder has no unminted balance (e.g. an account that received its tokens via transfer rather than `wrap`).

## Notes

With the default `_checkConfidentialTotalSupply`, wrapping reverts atomically on overflow, so no unminted amount is ever recorded — this bookkeeping only becomes relevant for derived contracts whose overflow handling lets `_update` silently cap instead of reverting. This is documented on `_unmintedAmounts`.

Existing wrapper tests pass; no test yet exercises a nonzero unminted balance (would require a mock that permits silent capping).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accounting for wrapped amounts paid for but not minted when the confidential supply cap is reached.
  * Holders can now redeem these tracked amounts through the unwrap process.

* **Bug Fixes**
  * Improved unwrap handling to consume eligible unminted amounts before burning confidential balances.
  * Enhanced balance tracking for initialized and uninitialized encrypted values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->