### PR TITLE
Run shouldBehaveLikeERC7984 from all applicable extensions

### DIFF
--- a/contracts/mocks/token/ERC7984/extensions/ERC7984RestrictedMock.sol
+++ b/contracts/mocks/token/ERC7984/extensions/ERC7984RestrictedMock.sol
@@ -2,20 +2,20 @@
 
 pragma solidity ^0.8.27;
 
-import {ZamaEthereumConfig} from "@fhevm/solidity/config/ZamaConfig.sol";
-import {FHE} from "@fhevm/solidity/lib/FHE.sol";
+import {FHE, euint64} from "@fhevm/solidity/lib/FHE.sol";
 import {ERC7984Restricted} from "../../../../token/ERC7984/extensions/ERC7984Restricted.sol";
+import {ERC7984Mock} from "../ERC7984Mock.sol";
 
-abstract contract ERC7984RestrictedMock is ERC7984Restricted, ZamaEthereumConfig {
-    function _mint(address to, uint64 amount) internal {
-        _mint(to, FHE.asEuint64(amount));
-    }
-
-    function _burn(address from, uint64 amount) internal {
-        _burn(from, FHE.asEuint64(amount));
-    }
-
+abstract contract ERC7984RestrictedMock is ERC7984Mock, ERC7984Restricted {
     function transfer(address to, uint64 amount) public {
         _transfer(msg.sender, to, FHE.asEuint64(amount));
+    }
+
+    function _update(
+        address from,
+        address to,
+        euint64 amount
+    ) internal virtual override(ERC7984Mock, ERC7984Restricted) returns (euint64) {
+        return super._update(from, to, amount);
     }
 }

--- a/test/token/ERC7984/ERC7984.behaviour.ts
+++ b/test/token/ERC7984/ERC7984.behaviour.ts
@@ -1,9 +1,6 @@
-import { ERC7984ReceiverMock } from '../../../types';
 import { $ERC7984Mock } from '../../../types/contracts-exposed/mocks/token/ERC7984/ERC7984Mock.sol/$ERC7984Mock';
 import { allowHandle } from '../../helpers/accounts';
-import { deployERC7984Fixture } from './ERC7984.test';
 import { FhevmType } from '@fhevm/hardhat-plugin';
-import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
 import hre, { ethers, fhevm } from 'hardhat';
 
@@ -11,105 +8,124 @@ const name = 'ConfidentialFungibleToken';
 const symbol = 'CFT';
 const uri = 'https://example.com/metadata';
 
-function shouldBehaveLikeERC7984(contract?: string, ...extraDeploymentArgs: any[]) {
-  const deployFixture = () => deployERC7984Fixture(contract, extraDeploymentArgs);
+// Deploys an ERC7984 mock (or a compatible extension mock) and mints 1000 tokens to `holder`.
+// Returns the props consumed by `shouldBehaveLikeERC7984`, meant to be assigned onto the Mocha
+// context via `Object.assign(this, await deployERC7984Fixture())` in a `beforeEach` hook.
+async function deployERC7984Fixture(contract: string = '$ERC7984Mock', extraDeploymentArgs: any[] = []) {
+  const [holder, recipient, operator, anyone] = await ethers.getSigners();
+  const token = (await ethers.deployContract(contract, [
+    name,
+    symbol,
+    uri,
+    ...extraDeploymentArgs,
+  ])) as any as $ERC7984Mock;
+  const encryptedInput = await fhevm
+    .createEncryptedInput(await token.getAddress(), holder.address)
+    .add64(1000)
+    .encrypt();
+  await token
+    .connect(holder)
+    ['$_mint(address,bytes32,bytes)'](holder, encryptedInput.handles[0], encryptedInput.inputProof);
+  return { token, holder, recipient, operator, anyone };
+}
 
-  describe('ERC7984 behaviour', function () {
+// Shared behaviour for ERC7984 tokens. Callers pass the mock contract name (and any extra
+// constructor args); the suite deploys it and assigns `token`, `holder`, `recipient`, `operator`
+// and `anyone` onto the Mocha context before each test.
+function shouldBehaveLikeERC7984(contract?: string, ...extraDeploymentArgs: any[]) {
+  describe('behaves like ERC7984', function () {
+    beforeEach(async function () {
+      Object.assign(this, await deployERC7984Fixture(contract, extraDeploymentArgs));
+    });
+
     describe('constructor', function () {
       it('sets the name', async function () {
-        const { token } = await deployFixture();
-        await expect(token.name()).to.eventually.equal(name);
+        await expect(this.token.name()).to.eventually.equal(name);
       });
 
       it('sets the symbol', async function () {
-        const { token } = await deployFixture();
-        await expect(token.symbol()).to.eventually.equal(symbol);
+        await expect(this.token.symbol()).to.eventually.equal(symbol);
       });
 
       it('sets the uri', async function () {
-        const { token } = await deployFixture();
-        await expect(token.contractURI()).to.eventually.equal(uri);
+        await expect(this.token.contractURI()).to.eventually.equal(uri);
       });
 
       it('decimals is 6', async function () {
-        const { token } = await deployFixture();
-        await expect(token.decimals()).to.eventually.equal(6);
+        await expect(this.token.decimals()).to.eventually.equal(6);
       });
     });
 
     describe('confidentialBalanceOf', function () {
       it('handle can be reencryped by owner', async function () {
-        const { token, holder } = await deployFixture();
-        const balanceOfHandleHolder = await token.confidentialBalanceOf(holder);
+        const balanceOfHandleHolder = await this.token.confidentialBalanceOf(this.holder);
         await expect(
-          fhevm.userDecryptEuint(FhevmType.euint64, balanceOfHandleHolder, await token.getAddress(), holder),
+          fhevm.userDecryptEuint(FhevmType.euint64, balanceOfHandleHolder, await this.token.getAddress(), this.holder),
         ).to.eventually.equal(1000);
       });
 
       it('handle cannot be reencryped by non-owner', async function () {
-        const { token, holder, anyone } = await deployFixture();
-        const balanceOfHandleHolder = await token.confidentialBalanceOf(holder);
+        const balanceOfHandleHolder = await this.token.confidentialBalanceOf(this.holder);
         await expect(
-          fhevm.userDecryptEuint(FhevmType.euint64, balanceOfHandleHolder, await token.getAddress(), anyone),
-        ).to.be.rejectedWith(generateReencryptionErrorMessage(balanceOfHandleHolder, anyone.address));
+          fhevm.userDecryptEuint(FhevmType.euint64, balanceOfHandleHolder, await this.token.getAddress(), this.anyone),
+        ).to.be.rejectedWith(generateReencryptionErrorMessage(balanceOfHandleHolder, this.anyone.address));
       });
     });
 
     describe('transfer', function () {
       for (const asSender of [true, false]) {
         describe(asSender ? 'as sender' : 'as operator', function () {
-          let [holder, recipient, operator]: HardhatEthersSigner[] = [];
-          let token: $ERC7984Mock;
           beforeEach(async function () {
-            ({ token, holder, recipient, operator } = await deployFixture());
             if (!asSender) {
               const timestamp = (await ethers.provider.getBlock('latest'))!.timestamp + 100;
-              await token.connect(holder).setOperator(operator.address, timestamp);
+              await this.token.connect(this.holder).setOperator(this.operator.address, timestamp);
             }
           });
 
           if (!asSender) {
             for (const withCallback of [false, true]) {
               describe(withCallback ? 'with callback' : 'without callback', function () {
-                let encryptedInput: any;
-                let params: any;
-
                 beforeEach(async function () {
-                  encryptedInput = await fhevm
-                    .createEncryptedInput(await token.getAddress(), operator.address)
+                  const encryptedInput = await fhevm
+                    .createEncryptedInput(await this.token.getAddress(), this.operator.address)
                     .add64(100)
                     .encrypt();
 
-                  params = [holder.address, recipient.address, encryptedInput.handles[0], encryptedInput.inputProof];
+                  this.params = [
+                    this.holder.address,
+                    this.recipient.address,
+                    encryptedInput.handles[0],
+                    encryptedInput.inputProof,
+                  ];
                   if (withCallback) {
-                    params.push('0x');
+                    this.params.push('0x');
                   }
                 });
 
                 it('without operator approval should fail', async function () {
-                  await token.$_setOperator(holder, operator, 0);
+                  await this.token.$_setOperator(this.holder, this.operator, 0);
 
                   await expect(
-                    token
-                      .connect(operator)
+                    this.token
+                      .connect(this.operator)
                       [
                         withCallback
                           ? 'confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)'
                           : 'confidentialTransferFrom(address,address,bytes32,bytes)'
-                      ](...params),
+                      ](...this.params),
                   )
-                    .to.be.revertedWithCustomError(token, 'ERC7984UnauthorizedSpender')
-                    .withArgs(holder.address, operator.address);
+                    .to.be.revertedWithCustomError(this.token, 'ERC7984UnauthorizedSpender')
+                    .withArgs(this.holder.address, this.operator.address);
                 });
 
                 it('should be successful', async function () {
-                  await token
-                    .connect(operator)
+                  await this.token
+                    .connect(this.operator)
                     [
                       withCallback
                         ? 'confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)'
                         : 'confidentialTransferFrom(address,address,bytes32,bytes)'
-                    ](...params);
+                    ](...this.params);
                 });
               });
             }
@@ -119,20 +135,20 @@ function shouldBehaveLikeERC7984(contract?: string, ...extraDeploymentArgs: any[
           if (asSender) {
             it('to zero address', async function () {
               const encryptedInput = await fhevm
-                .createEncryptedInput(await token.getAddress(), holder.address)
+                .createEncryptedInput(await this.token.getAddress(), this.holder.address)
                 .add64(100)
                 .encrypt();
 
               await expect(
-                token
-                  .connect(holder)
+                this.token
+                  .connect(this.holder)
                   ['confidentialTransfer(address,bytes32,bytes)'](
                     ethers.ZeroAddress,
                     encryptedInput.handles[0],
                     encryptedInput.inputProof,
                   ),
               )
-                .to.be.revertedWithCustomError(token, 'ERC7984InvalidReceiver')
+                .to.be.revertedWithCustomError(this.token, 'ERC7984InvalidReceiver')
                 .withArgs(ethers.ZeroAddress);
             });
           }
@@ -142,53 +158,81 @@ function shouldBehaveLikeERC7984(contract?: string, ...extraDeploymentArgs: any[
               const transferAmount = sufficientBalance ? 400 : 1100;
 
               const encryptedInput = await fhevm
-                .createEncryptedInput(await token.getAddress(), asSender ? holder.address : operator.address)
+                .createEncryptedInput(
+                  await this.token.getAddress(),
+                  asSender ? this.holder.address : this.operator.address,
+                )
                 .add64(transferAmount)
                 .encrypt();
 
               let tx;
               if (asSender) {
-                tx = await token
-                  .connect(holder)
+                tx = await this.token
+                  .connect(this.holder)
                   ['confidentialTransfer(address,bytes32,bytes)'](
-                    recipient.address,
+                    this.recipient.address,
                     encryptedInput.handles[0],
                     encryptedInput.inputProof,
                   );
               } else {
-                tx = await token
-                  .connect(operator)
+                tx = await this.token
+                  .connect(this.operator)
                   ['confidentialTransferFrom(address,address,bytes32,bytes)'](
-                    holder.address,
-                    recipient.address,
+                    this.holder.address,
+                    this.recipient.address,
                     encryptedInput.handles[0],
                     encryptedInput.inputProof,
                   );
               }
-              const transferEvent = (await tx.wait()).logs.filter((log: any) => log.address === token.target)[0];
-              expect(transferEvent.args[0]).to.equal(holder.address);
-              expect(transferEvent.args[1]).to.equal(recipient.address);
+              const transferEvent = (await tx.wait()).logs.filter((log: any) => log.address === this.token.target)[0];
+              expect(transferEvent.args[0]).to.equal(this.holder.address);
+              expect(transferEvent.args[1]).to.equal(this.recipient.address);
 
               const transferAmountHandle = transferEvent.args[2];
-              const holderBalanceHandle = await token.confidentialBalanceOf(holder);
-              const recipientBalanceHandle = await token.confidentialBalanceOf(recipient);
+              const holderBalanceHandle = await this.token.confidentialBalanceOf(this.holder);
+              const recipientBalanceHandle = await this.token.confidentialBalanceOf(this.recipient);
 
               await expect(
-                fhevm.userDecryptEuint(FhevmType.euint64, transferAmountHandle, await token.getAddress(), holder),
+                fhevm.userDecryptEuint(
+                  FhevmType.euint64,
+                  transferAmountHandle,
+                  await this.token.getAddress(),
+                  this.holder,
+                ),
               ).to.eventually.equal(sufficientBalance ? transferAmount : 0);
               await expect(
-                fhevm.userDecryptEuint(FhevmType.euint64, transferAmountHandle, await token.getAddress(), recipient),
+                fhevm.userDecryptEuint(
+                  FhevmType.euint64,
+                  transferAmountHandle,
+                  await this.token.getAddress(),
+                  this.recipient,
+                ),
               ).to.eventually.equal(sufficientBalance ? transferAmount : 0);
               // Other can not reencrypt the transfer amount
               await expect(
-                fhevm.userDecryptEuint(FhevmType.euint64, transferAmountHandle, await token.getAddress(), operator),
-              ).to.be.rejectedWith(generateReencryptionErrorMessage(transferAmountHandle, operator.address));
+                fhevm.userDecryptEuint(
+                  FhevmType.euint64,
+                  transferAmountHandle,
+                  await this.token.getAddress(),
+                  this.operator,
+                ),
+              ).to.be.rejectedWith(generateReencryptionErrorMessage(transferAmountHandle, this.operator.address));
 
               await expect(
-                fhevm.userDecryptEuint(FhevmType.euint64, holderBalanceHandle, await token.getAddress(), holder),
+                fhevm.userDecryptEuint(
+                  FhevmType.euint64,
+                  holderBalanceHandle,
+                  await this.token.getAddress(),
+                  this.holder,
+                ),
               ).to.eventually.equal(1000 - (sufficientBalance ? transferAmount : 0));
               await expect(
-                fhevm.userDecryptEuint(FhevmType.euint64, recipientBalanceHandle, await token.getAddress(), recipient),
+                fhevm.userDecryptEuint(
+                  FhevmType.euint64,
+                  recipientBalanceHandle,
+                  await this.token.getAddress(),
+                  this.recipient,
+                ),
               ).to.eventually.equal(sufficientBalance ? transferAmount : 0);
             });
           }
@@ -225,54 +269,60 @@ function shouldBehaveLikeERC7984(contract?: string, ...extraDeploymentArgs: any[
             }
 
             it('full balance', async function () {
-              const { token, holder, recipient } = await deployFixture();
-              const fullBalanceHandle = await token.confidentialBalanceOf(holder);
+              const fullBalanceHandle = await this.token.confidentialBalanceOf(this.holder);
 
-              await callTransfer(token, holder, recipient, fullBalanceHandle);
+              await callTransfer(this.token, this.holder, this.recipient, fullBalanceHandle);
 
               await expect(
                 fhevm.userDecryptEuint(
                   FhevmType.euint64,
-                  await token.confidentialBalanceOf(recipient),
-                  await token.getAddress(),
-                  recipient,
+                  await this.token.confidentialBalanceOf(this.recipient),
+                  await this.token.getAddress(),
+                  this.recipient,
                 ),
               ).to.eventually.equal(1000);
             });
 
             it('other user balance should revert', async function () {
-              const { token, holder, recipient } = await deployFixture();
               const encryptedInput = await fhevm
-                .createEncryptedInput(await token.getAddress(), holder.address)
+                .createEncryptedInput(await this.token.getAddress(), this.holder.address)
                 .add64(100)
                 .encrypt();
 
-              await token
-                .connect(holder)
-                ['$_mint(address,bytes32,bytes)'](recipient, encryptedInput.handles[0], encryptedInput.inputProof);
+              await this.token
+                .connect(this.holder)
+                ['$_mint(address,bytes32,bytes)'](this.recipient, encryptedInput.handles[0], encryptedInput.inputProof);
 
-              const recipientBalanceHandle = await token.confidentialBalanceOf(recipient);
-              await expect(callTransfer(token, holder, recipient, recipientBalanceHandle))
-                .to.be.revertedWithCustomError(token, 'ERC7984UnauthorizedUseOfEncryptedAmount')
-                .withArgs(recipientBalanceHandle, holder);
+              const recipientBalanceHandle = await this.token.confidentialBalanceOf(this.recipient);
+              await expect(callTransfer(this.token, this.holder, this.recipient, recipientBalanceHandle))
+                .to.be.revertedWithCustomError(this.token, 'ERC7984UnauthorizedUseOfEncryptedAmount')
+                .withArgs(recipientBalanceHandle, this.holder);
             });
 
             if (usingTransferFrom) {
               describe('without operator approval', function () {
-                let [holder, recipient, operator]: HardhatEthersSigner[] = [];
-                let token: $ERC7984Mock;
                 beforeEach(async function () {
-                  ({ token, holder, recipient, operator } = await deployFixture());
-                  await token.connect(holder).setOperator(operator.address, 0);
-                  await allowHandle(hre, holder, operator, await token.confidentialBalanceOf(holder));
+                  await this.token.connect(this.holder).setOperator(this.operator.address, 0);
+                  await allowHandle(
+                    hre,
+                    this.holder,
+                    this.operator,
+                    await this.token.confidentialBalanceOf(this.holder),
+                  );
                 });
 
                 it('should revert', async function () {
                   await expect(
-                    callTransfer(token, holder, recipient, await token.confidentialBalanceOf(holder), operator),
+                    callTransfer(
+                      this.token,
+                      this.holder,
+                      this.recipient,
+                      await this.token.confidentialBalanceOf(this.holder),
+                      this.operator,
+                    ),
                   )
-                    .to.be.revertedWithCustomError(token, 'ERC7984UnauthorizedSpender')
-                    .withArgs(holder.address, operator.address);
+                    .to.be.revertedWithCustomError(this.token, 'ERC7984UnauthorizedSpender')
+                    .withArgs(this.holder.address, this.operator.address);
                 });
               });
             }
@@ -281,126 +331,130 @@ function shouldBehaveLikeERC7984(contract?: string, ...extraDeploymentArgs: any[
       });
 
       it('internal function reverts on from address zero', async function () {
-        const { token, holder, recipient } = await deployFixture();
         const encryptedInput = await fhevm
-          .createEncryptedInput(await token.getAddress(), holder.address)
+          .createEncryptedInput(await this.token.getAddress(), this.holder.address)
           .add64(100)
           .encrypt();
 
         await expect(
-          token
-            .connect(holder)
+          this.token
+            .connect(this.holder)
             ['$_transfer(address,address,bytes32,bytes)'](
               ethers.ZeroAddress,
-              recipient.address,
+              this.recipient.address,
               encryptedInput.handles[0],
               encryptedInput.inputProof,
             ),
         )
-          .to.be.revertedWithCustomError(token, 'ERC7984InvalidSender')
+          .to.be.revertedWithCustomError(this.token, 'ERC7984InvalidSender')
           .withArgs(ethers.ZeroAddress);
       });
     });
 
     describe('transfer with callback', function () {
-      let [holder, recipient]: HardhatEthersSigner[] = [];
-      let token: $ERC7984Mock;
-      let recipientContract: ERC7984ReceiverMock;
-      let encryptedInput: any;
       beforeEach(async function () {
-        ({ token, holder, recipient } = await deployFixture());
-        recipientContract = await ethers.deployContract('ERC7984ReceiverMock');
+        this.recipientContract = await ethers.deployContract('ERC7984ReceiverMock');
 
-        encryptedInput = await fhevm
-          .createEncryptedInput(await token.getAddress(), holder.address)
+        this.encryptedInput = await fhevm
+          .createEncryptedInput(await this.token.getAddress(), this.holder.address)
           .add64(1000)
           .encrypt();
       });
 
       for (const callbackSuccess of [false, true]) {
         it(`with callback running ${callbackSuccess ? 'successfully' : 'unsuccessfully'}`, async function () {
-          const tx = await token
-            .connect(holder)
+          const tx = await this.token
+            .connect(this.holder)
             ['confidentialTransferAndCall(address,bytes32,bytes,bytes)'](
-              recipientContract.target,
-              encryptedInput.handles[0],
-              encryptedInput.inputProof,
+              this.recipientContract.target,
+              this.encryptedInput.handles[0],
+              this.encryptedInput.inputProof,
               ethers.AbiCoder.defaultAbiCoder().encode(['bool'], [callbackSuccess]),
             );
 
           await expect(
             fhevm.userDecryptEuint(
               FhevmType.euint64,
-              await token.confidentialBalanceOf(holder),
-              await token.getAddress(),
-              holder,
+              await this.token.confidentialBalanceOf(this.holder),
+              await this.token.getAddress(),
+              this.holder,
             ),
           ).to.eventually.equal(callbackSuccess ? 0 : 1000);
 
           // Verify event contents
-          expect(tx).to.emit(recipientContract, 'ConfidentialTransferCallback').withArgs(callbackSuccess);
-          const transferEvents = (await tx.wait()).logs.filter((log: any) => log.address === token.target);
+          expect(tx).to.emit(this.recipientContract, 'ConfidentialTransferCallback').withArgs(callbackSuccess);
+          const transferEvents = (await tx.wait()).logs.filter((log: any) => log.address === this.token.target);
 
           const outboundTransferEvent = transferEvents[0];
           const inboundTransferEvent = transferEvents[1];
 
-          expect(outboundTransferEvent.args[0]).to.equal(holder.address);
-          expect(outboundTransferEvent.args[1]).to.equal(recipientContract.target);
+          expect(outboundTransferEvent.args[0]).to.equal(this.holder.address);
+          expect(outboundTransferEvent.args[1]).to.equal(this.recipientContract.target);
           await expect(
-            fhevm.userDecryptEuint(FhevmType.euint64, outboundTransferEvent.args[2], await token.getAddress(), holder),
+            fhevm.userDecryptEuint(
+              FhevmType.euint64,
+              outboundTransferEvent.args[2],
+              await this.token.getAddress(),
+              this.holder,
+            ),
           ).to.eventually.equal(1000);
 
-          expect(inboundTransferEvent.args[0]).to.equal(recipientContract.target);
-          expect(inboundTransferEvent.args[1]).to.equal(holder.address);
+          expect(inboundTransferEvent.args[0]).to.equal(this.recipientContract.target);
+          expect(inboundTransferEvent.args[1]).to.equal(this.holder.address);
           await expect(
-            fhevm.userDecryptEuint(FhevmType.euint64, inboundTransferEvent.args[2], await token.getAddress(), holder),
+            fhevm.userDecryptEuint(
+              FhevmType.euint64,
+              inboundTransferEvent.args[2],
+              await this.token.getAddress(),
+              this.holder,
+            ),
           ).to.eventually.equal(callbackSuccess ? 0 : 1000);
         });
       }
 
       it('with callback reverting without a reason', async function () {
         await expect(
-          token
-            .connect(holder)
+          this.token
+            .connect(this.holder)
             ['confidentialTransferAndCall(address,bytes32,bytes,bytes)'](
-              recipientContract.target,
-              encryptedInput.handles[0],
-              encryptedInput.inputProof,
+              this.recipientContract.target,
+              this.encryptedInput.handles[0],
+              this.encryptedInput.inputProof,
               '0x',
             ),
         )
-          .to.be.revertedWithCustomError(token, 'ERC7984InvalidReceiver')
-          .withArgs(recipientContract.target);
+          .to.be.revertedWithCustomError(this.token, 'ERC7984InvalidReceiver')
+          .withArgs(this.recipientContract.target);
       });
 
       it('with callback reverting with a custom error', async function () {
         await expect(
-          token
-            .connect(holder)
+          this.token
+            .connect(this.holder)
             ['confidentialTransferAndCall(address,bytes32,bytes,bytes)'](
-              recipientContract.target,
-              encryptedInput.handles[0],
-              encryptedInput.inputProof,
+              this.recipientContract.target,
+              this.encryptedInput.handles[0],
+              this.encryptedInput.inputProof,
               ethers.AbiCoder.defaultAbiCoder().encode(['uint8'], [2]),
             ),
         )
-          .to.be.revertedWithCustomError(recipientContract, 'InvalidInput')
+          .to.be.revertedWithCustomError(this.recipientContract, 'InvalidInput')
           .withArgs(2);
       });
 
       it('to an EOA', async function () {
-        await token
-          .connect(holder)
+        await this.token
+          .connect(this.holder)
           ['confidentialTransferAndCall(address,bytes32,bytes,bytes)'](
-            recipient,
-            encryptedInput.handles[0],
-            encryptedInput.inputProof,
+            this.recipient,
+            this.encryptedInput.handles[0],
+            this.encryptedInput.inputProof,
             '0x',
           );
 
-        const balanceOfHandle = await token.confidentialBalanceOf(recipient);
+        const balanceOfHandle = await this.token.confidentialBalanceOf(this.recipient);
         await expect(
-          fhevm.userDecryptEuint(FhevmType.euint64, balanceOfHandle, await token.getAddress(), recipient),
+          fhevm.userDecryptEuint(FhevmType.euint64, balanceOfHandle, await this.token.getAddress(), this.recipient),
         ).to.eventually.equal(1000);
       });
     });
@@ -411,4 +465,4 @@ function generateReencryptionErrorMessage(handle: string, account: string): stri
   return `User ${account} is not authorized to user decrypt handle ${handle}`;
 }
 
-export { shouldBehaveLikeERC7984 };
+export { deployERC7984Fixture, shouldBehaveLikeERC7984 };

--- a/test/token/ERC7984/ERC7984.test.ts
+++ b/test/token/ERC7984/ERC7984.test.ts
@@ -1,90 +1,65 @@
-import { $ERC7984Mock } from '../../../types/contracts-exposed/mocks/token/ERC7984/ERC7984Mock.sol/$ERC7984Mock';
 import { INTERFACE_IDS, INVALID_ID } from '../../helpers/interface';
-import { shouldBehaveLikeERC7984 } from './ERC7984.behaviour';
+import { deployERC7984Fixture, shouldBehaveLikeERC7984 } from './ERC7984.behaviour';
 import { FhevmType } from '@fhevm/hardhat-plugin';
-import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers, fhevm } from 'hardhat';
 
-const contract = '$ERC7984Mock';
-const name = 'ConfidentialFungibleToken';
-const symbol = 'CFT';
-const uri = 'https://example.com/metadata';
-
-async function deployFixture(_contract?: string, extraDeploymentArgs: any[] = []) {
-  const [holder, recipient, operator, anyone] = await ethers.getSigners();
-  const token = (await ethers.deployContract(_contract ? _contract : contract, [
-    name,
-    symbol,
-    uri,
-    ...extraDeploymentArgs,
-  ])) as any as $ERC7984Mock;
-  const encryptedInput = await fhevm
-    .createEncryptedInput(await token.getAddress(), holder.address)
-    .add64(1000)
-    .encrypt();
-  await token
-    .connect(holder)
-    ['$_mint(address,bytes32,bytes)'](holder, encryptedInput.handles[0], encryptedInput.inputProof);
-  return { token, holder, recipient, operator, anyone };
-}
-
 describe('ERC7984', function () {
+  beforeEach(async function () {
+    Object.assign(this, await deployERC7984Fixture());
+  });
+
   describe('ERC165', function () {
     it('should support interface', async function () {
-      const { token } = await deployFixture();
-      await expect(token.supportsInterface(INTERFACE_IDS.ERC7984)).to.eventually.be.true;
-      await expect(token.supportsInterface(INTERFACE_IDS.ERC7984ERC20Wrapper)).to.eventually.be.false;
-      await expect(token.supportsInterface(INTERFACE_IDS.ERC7984RWA)).to.eventually.be.false;
+      await expect(this.token.supportsInterface(INTERFACE_IDS.ERC7984)).to.eventually.be.true;
+      await expect(this.token.supportsInterface(INTERFACE_IDS.ERC7984ERC20Wrapper)).to.eventually.be.false;
+      await expect(this.token.supportsInterface(INTERFACE_IDS.ERC7984RWA)).to.eventually.be.false;
     });
 
     it('should not support interface', async function () {
-      const { token } = await deployFixture();
-      await expect(token.supportsInterface(INVALID_ID)).to.eventually.be.false;
+      await expect(this.token.supportsInterface(INVALID_ID)).to.eventually.be.false;
     });
   });
 
   describe('mint', function () {
     for (const existingUser of [false, true]) {
       it(`to ${existingUser ? 'existing' : 'new'} user`, async function () {
-        const { token, holder } = await deployFixture();
         if (existingUser) {
           const encryptedInput = await fhevm
-            .createEncryptedInput(await token.getAddress(), holder.address)
+            .createEncryptedInput(await this.token.getAddress(), this.holder.address)
             .add64(1000)
             .encrypt();
 
-          await token
-            .connect(holder)
-            ['$_mint(address,bytes32,bytes)'](holder, encryptedInput.handles[0], encryptedInput.inputProof);
+          await this.token
+            .connect(this.holder)
+            ['$_mint(address,bytes32,bytes)'](this.holder, encryptedInput.handles[0], encryptedInput.inputProof);
         }
 
-        const balanceOfHandleHolder = await token.confidentialBalanceOf(holder);
+        const balanceOfHandleHolder = await this.token.confidentialBalanceOf(this.holder);
         await expect(
-          fhevm.userDecryptEuint(FhevmType.euint64, balanceOfHandleHolder, await token.getAddress(), holder),
+          fhevm.userDecryptEuint(FhevmType.euint64, balanceOfHandleHolder, await this.token.getAddress(), this.holder),
         ).to.eventually.equal(existingUser ? 2000 : 1000);
 
         // Check total supply
-        const totalSupplyHandle = await token.confidentialTotalSupply();
+        const totalSupplyHandle = await this.token.confidentialTotalSupply();
         await expect(
-          fhevm.userDecryptEuint(FhevmType.euint64, totalSupplyHandle, await token.getAddress(), holder),
+          fhevm.userDecryptEuint(FhevmType.euint64, totalSupplyHandle, await this.token.getAddress(), this.holder),
         ).to.eventually.equal(existingUser ? 2000 : 1000);
       });
     }
 
     it('from zero address', async function () {
-      const { token, holder } = await deployFixture();
       const encryptedInput = await fhevm
-        .createEncryptedInput(await token.getAddress(), holder.address)
+        .createEncryptedInput(await this.token.getAddress(), this.holder.address)
         .add64(400)
         .encrypt();
 
       await expect(
-        token
-          .connect(holder)
+        this.token
+          .connect(this.holder)
           ['$_mint(address,bytes32,bytes)'](ethers.ZeroAddress, encryptedInput.handles[0], encryptedInput.inputProof),
       )
-        .to.be.revertedWithCustomError(token, 'ERC7984InvalidReceiver')
+        .to.be.revertedWithCustomError(this.token, 'ERC7984InvalidReceiver')
         .withArgs(ethers.ZeroAddress);
     });
   });
@@ -92,134 +67,126 @@ describe('ERC7984', function () {
   describe('burn', function () {
     for (const sufficientBalance of [false, true]) {
       it(`from a user with ${sufficientBalance ? 'sufficient' : 'insufficient'} balance`, async function () {
-        const { token, holder } = await deployFixture();
         const burnAmount = sufficientBalance ? 400 : 1100;
 
         const encryptedInput = await fhevm
-          .createEncryptedInput(await token.getAddress(), holder.address)
+          .createEncryptedInput(await this.token.getAddress(), this.holder.address)
           .add64(burnAmount)
           .encrypt();
 
-        await token
-          .connect(holder)
-          ['$_burn(address,bytes32,bytes)'](holder, encryptedInput.handles[0], encryptedInput.inputProof);
+        await this.token
+          .connect(this.holder)
+          ['$_burn(address,bytes32,bytes)'](this.holder, encryptedInput.handles[0], encryptedInput.inputProof);
 
-        const balanceOfHandleHolder = await token.confidentialBalanceOf(holder);
+        const balanceOfHandleHolder = await this.token.confidentialBalanceOf(this.holder);
         await expect(
-          fhevm.userDecryptEuint(FhevmType.euint64, balanceOfHandleHolder, await token.getAddress(), holder),
+          fhevm.userDecryptEuint(FhevmType.euint64, balanceOfHandleHolder, await this.token.getAddress(), this.holder),
         ).to.eventually.equal(sufficientBalance ? 600 : 1000);
 
         // Check total supply
-        const totalSupplyHandle = await token.confidentialTotalSupply();
+        const totalSupplyHandle = await this.token.confidentialTotalSupply();
         await expect(
-          fhevm.userDecryptEuint(FhevmType.euint64, totalSupplyHandle, await token.getAddress(), holder),
+          fhevm.userDecryptEuint(FhevmType.euint64, totalSupplyHandle, await this.token.getAddress(), this.holder),
         ).to.eventually.equal(sufficientBalance ? 600 : 1000);
       });
     }
 
     it('from zero address', async function () {
-      const { token, holder } = await deployFixture();
       const encryptedInput = await fhevm
-        .createEncryptedInput(await token.getAddress(), holder.address)
+        .createEncryptedInput(await this.token.getAddress(), this.holder.address)
         .add64(400)
         .encrypt();
 
       await expect(
-        token
-          .connect(holder)
+        this.token
+          .connect(this.holder)
           ['$_burn(address,bytes32,bytes)'](ethers.ZeroAddress, encryptedInput.handles[0], encryptedInput.inputProof),
       )
-        .to.be.revertedWithCustomError(token, 'ERC7984InvalidSender')
+        .to.be.revertedWithCustomError(this.token, 'ERC7984InvalidSender')
         .withArgs(ethers.ZeroAddress);
     });
   });
 
   describe('disclose', function () {
-    let [holder, recipient]: HardhatEthersSigner[] = [];
-    let token: $ERC7984Mock;
-    let expectedAmount: any;
-    let expectedHandle: any;
-    let requester: HardhatEthersSigner | undefined;
-
     beforeEach(async function () {
-      ({ token, holder, recipient } = await deployFixture());
-      expectedAmount = undefined;
-      expectedHandle = undefined;
-      requester = undefined;
+      this.expectedAmount = undefined;
+      this.expectedHandle = undefined;
+      this.requester = undefined;
     });
 
     it('user balance', async function () {
-      const holderBalanceHandle = await token.confidentialBalanceOf(holder);
+      const holderBalanceHandle = await this.token.confidentialBalanceOf(this.holder);
 
-      await token.connect(holder).requestDiscloseEncryptedAmount(holderBalanceHandle);
+      await this.token.connect(this.holder).requestDiscloseEncryptedAmount(holderBalanceHandle);
 
-      requester = holder.address;
-      expectedAmount = 1000n;
-      expectedHandle = holderBalanceHandle;
+      this.requester = this.holder.address;
+      this.expectedAmount = 1000n;
+      this.expectedHandle = holderBalanceHandle;
     });
 
     it('transaction amount', async function () {
       const encryptedInput = await fhevm
-        .createEncryptedInput(await token.getAddress(), holder.address)
+        .createEncryptedInput(await this.token.getAddress(), this.holder.address)
         .add64(400)
         .encrypt();
 
-      const tx = await token['confidentialTransfer(address,bytes32,bytes)'](
-        recipient,
+      const tx = await this.token['confidentialTransfer(address,bytes32,bytes)'](
+        this.recipient,
         encryptedInput.handles[0],
         encryptedInput.inputProof,
       );
 
-      const transferEvent = (await tx.wait()).logs.filter((log: any) => log.address === token.target)[0];
+      const transferEvent = (await tx.wait()).logs.filter((log: any) => log.address === this.token.target)[0];
       const transferAmount = transferEvent.args[2];
 
-      await token.connect(recipient).requestDiscloseEncryptedAmount(transferAmount);
+      await this.token.connect(this.recipient).requestDiscloseEncryptedAmount(transferAmount);
 
-      requester = recipient.address;
-      expectedAmount = 400n;
-      expectedHandle = transferAmount;
+      this.requester = this.recipient.address;
+      this.expectedAmount = 400n;
+      this.expectedHandle = transferAmount;
     });
 
     it("other user's balance", async function () {
-      const holderBalanceHandle = await token.confidentialBalanceOf(holder);
+      const holderBalanceHandle = await this.token.confidentialBalanceOf(this.holder);
 
-      await expect(token.connect(recipient).requestDiscloseEncryptedAmount(holderBalanceHandle))
-        .to.be.revertedWithCustomError(token, 'ERC7984UnauthorizedUseOfEncryptedAmount')
-        .withArgs(holderBalanceHandle, recipient);
+      await expect(this.token.connect(this.recipient).requestDiscloseEncryptedAmount(holderBalanceHandle))
+        .to.be.revertedWithCustomError(this.token, 'ERC7984UnauthorizedUseOfEncryptedAmount')
+        .withArgs(holderBalanceHandle, this.recipient);
     });
 
     it('invalid signature reverts', async function () {
-      const holderBalanceHandle = await token.confidentialBalanceOf(holder);
-      await token.connect(holder).requestDiscloseEncryptedAmount(holderBalanceHandle);
+      const holderBalanceHandle = await this.token.confidentialBalanceOf(this.holder);
+      await this.token.connect(this.holder).requestDiscloseEncryptedAmount(holderBalanceHandle);
 
-      await expect(token.connect(holder).discloseEncryptedAmount(holderBalanceHandle, 0, '0x')).to.be.reverted;
+      await expect(this.token.connect(this.holder).discloseEncryptedAmount(holderBalanceHandle, 0, '0x')).to.be
+        .reverted;
     });
 
     afterEach(async function () {
-      if (expectedHandle === undefined || expectedAmount === undefined) return;
+      if (this.expectedHandle === undefined || this.expectedAmount === undefined) return;
 
-      const amountDiscloseRequestedEvent = (await token.queryFilter(token.filters.AmountDiscloseRequested()))[0];
+      const amountDiscloseRequestedEvent = (
+        await this.token.queryFilter(this.token.filters.AmountDiscloseRequested())
+      )[0];
 
-      expect(expectedHandle).to.equal(amountDiscloseRequestedEvent.args[0]);
-      expect(requester).to.equal(amountDiscloseRequestedEvent.args[1]);
+      expect(this.expectedHandle).to.equal(amountDiscloseRequestedEvent.args[0]);
+      expect(this.requester).to.equal(amountDiscloseRequestedEvent.args[1]);
 
-      const publicDecryptResults = await fhevm.publicDecrypt([expectedHandle]);
+      const publicDecryptResults = await fhevm.publicDecrypt([this.expectedHandle]);
 
       await expect(
-        token
-          .connect(holder)
+        this.token
+          .connect(this.holder)
           .discloseEncryptedAmount(
-            expectedHandle,
+            this.expectedHandle,
             publicDecryptResults.abiEncodedClearValues,
             publicDecryptResults.decryptionProof,
           ),
       )
-        .to.emit(token, 'AmountDisclosed')
-        .withArgs(expectedHandle, expectedAmount);
+        .to.emit(this.token, 'AmountDisclosed')
+        .withArgs(this.expectedHandle, this.expectedAmount);
     });
   });
 
-  shouldBehaveLikeERC7984(contract);
+  shouldBehaveLikeERC7984();
 });
-
-export { deployFixture as deployERC7984Fixture };

--- a/test/token/ERC7984/extensions/ERC7984Hooked.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984Hooked.test.ts
@@ -1,5 +1,6 @@
 import { $ERC7984Hooked } from '../../../../types/contracts-exposed/token/ERC7984/extensions/rwa/ERC7984Hooked.sol/$ERC7984Hooked';
 import { INTERFACE_IDS, INVALID_ID } from '../../../helpers/interface';
+import { shouldBehaveLikeERC7984 } from '../ERC7984.behaviour';
 import { FhevmType } from '@fhevm/hardhat-plugin';
 import { expect } from 'chai';
 import { ethers, fhevm } from 'hardhat';
@@ -143,4 +144,7 @@ describe('ERC7984Hooked', function () {
       });
     }
   });
+
+  // Arbitrary non-zero owner; the behaviour does not install modules so `_authorizeModuleChange` is never hit.
+  shouldBehaveLikeERC7984('$ERC7984HookedMock', '0x0000000000000000000000000000000000000001');
 });

--- a/test/token/ERC7984/extensions/ERC7984ObserverAccess.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984ObserverAccess.test.ts
@@ -1,3 +1,4 @@
+import { shouldBehaveLikeERC7984 } from '../ERC7984.behaviour';
 import { FhevmType } from '@fhevm/hardhat-plugin';
 import { mine } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
@@ -137,4 +138,6 @@ describe('ERC7984ObserverAccess', function () {
       ).to.eventually.equal(900);
     });
   });
+
+  shouldBehaveLikeERC7984('$ERC7984ObserverAccessMock');
 });

--- a/test/token/ERC7984/extensions/ERC7984Omnibus.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984Omnibus.test.ts
@@ -1,6 +1,7 @@
 import { IACL__factory } from '../../../../types';
 import { $ERC7984OmnibusMock } from '../../../../types/contracts-exposed/mocks/token/ERC7984/extensions/ERC7984OmnibusMock.sol/$ERC7984OmnibusMock';
 import { getAclAddress } from '../../../helpers/accounts';
+import { shouldBehaveLikeERC7984 } from '../ERC7984.behaviour';
 import { FhevmType } from '@fhevm/hardhat-plugin';
 import { expect } from 'chai';
 import { ethers, fhevm } from 'hardhat';
@@ -201,6 +202,8 @@ describe('ERC7984Omnibus', function () {
       }
     });
   }
+
+  shouldBehaveLikeERC7984('$ERC7984OmnibusMock');
 });
 
 const doConfidentialTransferOmnibus = (

--- a/test/token/ERC7984/extensions/ERC7984Restricted.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984Restricted.test.ts
@@ -1,6 +1,5 @@
 const { ethers, fhevm } = require('hardhat');
 const { expect } = require('chai');
-const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { shouldBehaveLikeERC7984 } = require('../ERC7984.behaviour');
 
 const initialSupply = 1000n;
@@ -16,7 +15,7 @@ async function fixture() {
 
 describe('ERC7984Restricted', function () {
   beforeEach(async function () {
-    Object.assign(this, await loadFixture(fixture));
+    Object.assign(this, await fixture());
   });
 
   describe('restriction management', function () {

--- a/test/token/ERC7984/extensions/ERC7984Restricted.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984Restricted.test.ts
@@ -1,6 +1,7 @@
 const { ethers, fhevm } = require('hardhat');
 const { expect } = require('chai');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const { shouldBehaveLikeERC7984 } = require('../ERC7984.behaviour');
 
 const initialSupply = 1000n;
 
@@ -235,4 +236,6 @@ describe('ERC7984Restricted', function () {
       });
     });
   });
+
+  shouldBehaveLikeERC7984('$ERC7984RestrictedMock');
 });

--- a/test/token/ERC7984/extensions/ERC7984Rwa.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984Rwa.test.ts
@@ -1,5 +1,6 @@
 import { callAndGetResult } from '../../../helpers/event';
 import { INTERFACE_IDS, INVALID_ID } from '../../../helpers/interface';
+import { shouldBehaveLikeERC7984 } from '../ERC7984.behaviour';
 import { FhevmType } from '@fhevm/hardhat-plugin';
 import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs';
 import { expect } from 'chai';
@@ -840,4 +841,9 @@ describe('ERC7984Rwa', function () {
       );
     });
   });
+
+  // In its default state (unpaused, no restrictions, nothing frozen) an RWA token behaves like a plain ERC7984.
+  // The `$_mint` helper bypasses the agent-only mint path, so the shared fixture can seed balances. The admin
+  // address is arbitrary since the behaviour never exercises agent/admin actions.
+  shouldBehaveLikeERC7984('$ERC7984RwaMock', '0x0000000000000000000000000000000000000001');
 });

--- a/test/token/ERC7984/extensions/ERC7984Votes.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984Votes.test.ts
@@ -1,3 +1,4 @@
+import { shouldBehaveLikeERC7984 } from '../ERC7984.behaviour';
 // @ts-ignore
 import { FhevmType } from '@fhevm/hardhat-plugin';
 import { mine } from '@nomicfoundation/hardhat-network-helpers';
@@ -285,4 +286,6 @@ describe('ERC7984Votes', function () {
       await expect(this.token.CLOCK_MODE()).to.be.revertedWithCustomError(this.token, 'ERC6372InconsistentClock');
     });
   });
+
+  shouldBehaveLikeERC7984('$ERC7984VotesMock');
 });


### PR DESCRIPTION
Applies the shared ERC7984 behaviour (already used by ERC7984 and ERC7984Freezable) to every extension whose mock behaves like a plain ERC7984 in its default state: ObserverAccess, Hooked, Omnibus, Votes, Rwa and Restricted.

Restricted's mock is rebased onto ERC7984Mock (mirroring the Freezable mock) so it inherits the $_mint(address,bytes32,bytes)/$_transfer helpers the shared fixture relies on; its existing uint64 transfer/mint surface is preserved. The ERC20Wrapper is intentionally excluded: it takes the underlying token as its first constructor arg and derives decimals() from it (not 6), so it cannot reuse the shared static fixture.