### PR TITLE
Check ACL access on token return in `VestingWalletConfidential`

### DIFF
--- a/.changeset/empty-rivers-allow.md
+++ b/.changeset/empty-rivers-allow.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': patch
+---
+
+`VestingWalletConfidential`: Ensure that tokens are allowed to access handles they return.

--- a/contracts/finance/VestingWalletConfidential.sol
+++ b/contracts/finance/VestingWalletConfidential.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Confidential Contracts (last updated v0.4.0) (finance/VestingWalletConfidential.sol)
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 import {FHE, euint64, euint128} from "@fhevm/solidity/lib/FHE.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/contracts/finance/VestingWalletConfidential.sol
+++ b/contracts/finance/VestingWalletConfidential.sol
@@ -138,17 +138,17 @@ abstract contract VestingWalletConfidential is OwnableUpgradeable, ReentrancyGua
     }
 
     /**
-     * @dev Reverts if `token` is not authorized (via the FHE ACL) to access the encrypted `handle` it returned.
+     * @dev Reverts if `token` is not authorized (via the ACL) to access the encrypted `handle`.
      *
      * {release} and {vestedAmount} consume encrypted handles returned by an arbitrary, caller-supplied `token`
      * (from {IERC7984-confidentialBalanceOf} and {IERC7984-confidentialTransfer}) and combine them with this
-     * wallet's own FHE permissions. Because FHE handles are global and not namespaced by token, a malicious
+     * wallet's own FHE permissions. Because FHE handles are global, and not namespaced by token, a malicious
      * `token` could return a handle belonging to a *different* {IERC7984} token this wallet holds, tricking the
-     * wallet into computing over -- and disclosing -- a confidential balance it is not meant to. Requiring that
+     * wallet into computing over a confidential balance it is not meant to. Requiring that
      * `token` itself is allowed on the handle ensures the handle genuinely originates from `token`.
      *
      * An uninitialized handle (e.g. a zero balance) is treated as zero by FHE arithmetic and is skipped, so
-     * honest zero-value releases do not revert. Mirrors {ERC7984HookModule-_accessHandle}.
+     * honest zero-value releases do not revert.
      */
     function _checkTokenHandleAccess(address token, euint64 handle) private view {
         require(

--- a/contracts/finance/VestingWalletConfidential.sol
+++ b/contracts/finance/VestingWalletConfidential.sol
@@ -140,13 +140,6 @@ abstract contract VestingWalletConfidential is OwnableUpgradeable, ReentrancyGua
     /**
      * @dev Reverts if `token` is not authorized (via the ACL) to access the encrypted `handle`.
      *
-     * {release} and {vestedAmount} consume encrypted handles returned by an arbitrary, caller-supplied `token`
-     * (from {IERC7984-confidentialBalanceOf} and {IERC7984-confidentialTransfer}) and combine them with this
-     * wallet's own FHE permissions. Because FHE handles are global, and not namespaced by token, a malicious
-     * `token` could return a handle belonging to a *different* {IERC7984} token this wallet holds, tricking the
-     * wallet into computing over a confidential balance it is not meant to. Requiring that
-     * `token` itself is allowed on the handle ensures the handle genuinely originates from `token`.
-     *
      * An uninitialized handle (e.g. a zero balance) is treated as zero by FHE arithmetic and is skipped, so
      * honest zero-value releases do not revert.
      */

--- a/contracts/finance/VestingWalletConfidential.sol
+++ b/contracts/finance/VestingWalletConfidential.sol
@@ -40,6 +40,9 @@ abstract contract VestingWalletConfidential is OwnableUpgradeable, ReentrancyGua
     /// @dev Emitted when releasable vested tokens are released.
     event VestingWalletConfidentialTokenReleased(address indexed token, euint64 amount);
 
+    /// @dev The `token` is not authorized (via the FHE ACL) to access the encrypted `handle` it returned.
+    error VestingWalletConfidentialUnauthorizedHandle(euint64 handle, address token);
+
     /// @dev Timestamp at which the vesting starts.
     function start() public view virtual returns (uint64) {
         return _getVestingWalletStorage()._start;
@@ -79,6 +82,7 @@ abstract contract VestingWalletConfidential is OwnableUpgradeable, ReentrancyGua
         euint64 amount = releasable(token);
         FHE.allowTransient(amount, token);
         euint64 amountSent = IERC7984(token).confidentialTransfer(owner(), amount);
+        _checkTokenHandleAccess(token, amountSent);
 
         // This could overflow if the total supply is re-sent `type(uint128).max/type(uint64).max` times. This is an accepted risk.
         euint128 newReleasedAmount = FHE.add(released(token), amountSent);
@@ -93,8 +97,9 @@ abstract contract VestingWalletConfidential is OwnableUpgradeable, ReentrancyGua
      * Default implementation is a linear vesting curve.
      */
     function vestedAmount(address token, uint48 timestamp) public virtual returns (euint128) {
-        return
-            _vestingSchedule(FHE.add(released(token), IERC7984(token).confidentialBalanceOf(address(this))), timestamp);
+        euint64 balance = IERC7984(token).confidentialBalanceOf(address(this));
+        _checkTokenHandleAccess(token, balance);
+        return _vestingSchedule(FHE.add(released(token), balance), timestamp);
     }
 
     /**
@@ -130,6 +135,26 @@ abstract contract VestingWalletConfidential is OwnableUpgradeable, ReentrancyGua
         } else {
             return FHE.div(FHE.mul(totalAllocation, (timestamp - start())), duration());
         }
+    }
+
+    /**
+     * @dev Reverts if `token` is not authorized (via the FHE ACL) to access the encrypted `handle` it returned.
+     *
+     * {release} and {vestedAmount} consume encrypted handles returned by an arbitrary, caller-supplied `token`
+     * (from {IERC7984-confidentialBalanceOf} and {IERC7984-confidentialTransfer}) and combine them with this
+     * wallet's own FHE permissions. Because FHE handles are global and not namespaced by token, a malicious
+     * `token` could return a handle belonging to a *different* {IERC7984} token this wallet holds, tricking the
+     * wallet into computing over -- and disclosing -- a confidential balance it is not meant to. Requiring that
+     * `token` itself is allowed on the handle ensures the handle genuinely originates from `token`.
+     *
+     * An uninitialized handle (e.g. a zero balance) is treated as zero by FHE arithmetic and is skipped, so
+     * honest zero-value releases do not revert. Mirrors {ERC7984HookModule-_accessHandle}.
+     */
+    function _checkTokenHandleAccess(address token, euint64 handle) private view {
+        require(
+            !FHE.isInitialized(handle) || FHE.isAllowed(handle, token),
+            VestingWalletConfidentialUnauthorizedHandle(handle, token)
+        );
     }
 
     function _getVestingWalletStorage() private pure returns (VestingWalletStorage storage $) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization checks for confidential vesting calculations and token releases.
  * Unauthorized encrypted handles now trigger a clear error instead of being processed.
  * Enhanced validation of confidential token balances before calculating vested amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->