### PR TITLE
Ensure `ERC7984` callback return value has ACL allowance

### DIFF
--- a/.changeset/ninety-bags-return.md
+++ b/.changeset/ninety-bags-return.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': patch
+---
+
+`ERC7984`: check that `IERC7984Receiver` has ACL access to the ebool they return.

--- a/contracts/mocks/token/ERC7984/ERC7984UnauthorizedReceiverMock.sol
+++ b/contracts/mocks/token/ERC7984/ERC7984UnauthorizedReceiverMock.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {ZamaEthereumConfig} from "@fhevm/solidity/config/ZamaConfig.sol";
+import {FHE, ebool, euint64} from "@fhevm/solidity/lib/FHE.sol";
+import {IERC7984Receiver} from "../../../interfaces/IERC7984Receiver.sol";
+
+/// @dev Receiver mock that can return an `ebool` it has no FHE ACL allowance for.
+///
+/// Used to assert that {ERC7984Utils-checkOnTransferReceived} rejects callback return
+/// values the recipient is not allowed to use.
+contract ERC7984UnauthorizedReceiverMock is IERC7984Receiver, ZamaEthereumConfig {
+    address private immutable _TOKEN;
+
+    ebool private _returnValue;
+
+    constructor(address token) {
+        _TOKEN = token;
+    }
+
+    /// @dev Creates and stores an encrypted bool with persistent ACL for this contract and `_TOKEN`.
+    function createReturnValue(bool value) external {
+        ebool result = FHE.asEbool(value);
+        FHE.allowThis(result);
+        FHE.allow(result, _TOKEN);
+        _returnValue = result;
+    }
+
+    /// @dev Stores `value` without granting this contract any ACL on it.
+    function setReturnValue(ebool value) external {
+        _returnValue = value;
+    }
+
+    function getReturnValue() external view returns (ebool) {
+        return _returnValue;
+    }
+
+    function onConfidentialTransferReceived(address, address, euint64, bytes calldata) external view returns (ebool) {
+        return _returnValue;
+    }
+}

--- a/contracts/token/ERC7984/utils/ERC7984Utils.sol
+++ b/contracts/token/ERC7984/utils/ERC7984Utils.sol
@@ -9,6 +9,8 @@ import {ERC7984} from "../ERC7984.sol";
 
 /// @dev Library that provides common {ERC7984} utility functions.
 library ERC7984Utils {
+    error ERC7984UtilsUnauthorizedUseOfEncryptedAmount(ebool retval, address to);
+
     /**
      * @dev Performs a transfer callback to the recipient of the transfer `to`. Should be invoked
      * after all transfers "withCallback" on a {ERC7984}.
@@ -30,6 +32,7 @@ library ERC7984Utils {
             try IERC7984Receiver(to).onConfidentialTransferReceived(operator, from, amount, data) returns (
                 ebool retval
             ) {
+                require(FHE.isAllowed(retval, to), ERC7984UtilsUnauthorizedUseOfEncryptedAmount(retval, to));
                 return retval;
             } catch (bytes memory reason) {
                 if (reason.length == 0) {

--- a/test/token/ERC7984/ERC7984.test.ts
+++ b/test/token/ERC7984/ERC7984.test.ts
@@ -464,6 +464,29 @@ describe('ERC7984', function () {
       });
     }
 
+    it('with callback returning encrypted value without recipient ACL', async function () {
+      const eboolOwner = await ethers.deployContract('ERC7984UnauthorizedReceiverMock', [this.token.target]);
+      await eboolOwner.createReturnValue(true);
+      const unauthorizedRetval = await eboolOwner.getReturnValue();
+
+      const maliciousReceiver = await ethers.deployContract('ERC7984UnauthorizedReceiverMock', [this.token.target]);
+      await maliciousReceiver.setReturnValue(unauthorizedRetval);
+
+      const utils = await ethers.getContractFactory('ERC7984Utils');
+      await expect(
+        this.token
+          .connect(this.holder)
+          ['confidentialTransferAndCall(address,bytes32,bytes,bytes)'](
+            maliciousReceiver.target,
+            this.encryptedInput.handles[0],
+            this.encryptedInput.inputProof,
+            '0x',
+          ),
+      )
+        .to.be.revertedWithCustomError(utils, 'ERC7984UtilsUnauthorizedUseOfEncryptedAmount')
+        .withArgs(unauthorizedRetval, maliciousReceiver.target);
+    });
+
     it('with callback reverting without a reason', async function () {
       await expect(
         this.token


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Callback-based confidential transfers now verify that returned encrypted values are authorized for the receiving address.
  * Transfers revert when a receiver returns an encrypted result without the required permissions, preventing unauthorized encrypted data use.

* **Tests**
  * Added coverage confirming unauthorized callback results are rejected with the appropriate error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->