### PR TITLE
Allow `IERC7984Receiver` to return an uninitialized handle

### DIFF
--- a/.changeset/empty-rivers-allow.md
+++ b/.changeset/empty-rivers-allow.md
@@ -2,4 +2,4 @@
 'openzeppelin-confidential-contracts': patch
 ---
 
-`VestingWalletConfidential`: Ensure that tokens are allowed to access handles they return.
+`VestingWalletConfidential`: Ensure that tokens are allowed to access handles they return (or the handle is uninitialized).

--- a/.changeset/ninety-bags-return.md
+++ b/.changeset/ninety-bags-return.md
@@ -2,4 +2,4 @@
 'openzeppelin-confidential-contracts': patch
 ---
 
-`ERC7984`: check that `IERC7984Receiver` has ACL access to the ebool they return.
+`ERC7984`: check that `IERC7984Receiver` has ACL access to the ebool they return (or the handle is uninitialized).

--- a/contracts/interfaces/IERC7984Receiver.sol
+++ b/contracts/interfaces/IERC7984Receiver.sol
@@ -10,7 +10,8 @@ interface IERC7984Receiver {
      * @dev Called upon receiving a confidential token transfer. Returns an encrypted boolean indicating success
      * of the callback. If false is returned, the token contract will attempt to refund the transfer.
      *
-     * NOTE: The calling contract (token) must be granted ACL allowance to read the confidential return value.
+     * NOTE: The calling contract (token) must be granted ACL allowance to read the confidential return value if
+     * it is initialized. Uninitialized return values are treated as a false boolean.
      *
      * WARNING: Do not manually refund the transfer AND return false, as this can lead to double refunds.
      */

--- a/contracts/token/ERC7984/utils/ERC7984Utils.sol
+++ b/contracts/token/ERC7984/utils/ERC7984Utils.sol
@@ -32,7 +32,10 @@ library ERC7984Utils {
             try IERC7984Receiver(to).onConfidentialTransferReceived(operator, from, amount, data) returns (
                 ebool retval
             ) {
-                require(FHE.isAllowed(retval, to), ERC7984UtilsUnauthorizedUseOfEncryptedAmount(retval, to));
+                require(
+                    !FHE.isInitialized(retval) || FHE.isAllowed(retval, to),
+                    ERC7984UtilsUnauthorizedUseOfEncryptedAmount(retval, to)
+                );
                 return retval;
             } catch (bytes memory reason) {
                 if (reason.length == 0) {

--- a/test/token/ERC7984/ERC7984.test.ts
+++ b/test/token/ERC7984/ERC7984.test.ts
@@ -490,12 +490,17 @@ describe('ERC7984', function () {
     it('with callback returning an uninitialized value', async function () {
       const receiver = await ethers.deployContract('ERC7984UnauthorizedReceiverMock', [this.token.target]);
 
+      const encryptedInput = await fhevm
+        .createEncryptedInput(this.token.target, this.holder.address)
+        .add64(100)
+        .encrypt();
+
       await this.token
         .connect(this.holder)
         ['confidentialTransferAndCall(address,bytes32,bytes,bytes)'](
           receiver.target,
-          this.encryptedInput.handles[0],
-          this.encryptedInput.inputProof,
+          encryptedInput.handles[0],
+          encryptedInput.inputProof,
           '0x',
         );
 

--- a/test/token/ERC7984/ERC7984.test.ts
+++ b/test/token/ERC7984/ERC7984.test.ts
@@ -487,6 +487,28 @@ describe('ERC7984', function () {
         .withArgs(unauthorizedRetval, maliciousReceiver.target);
     });
 
+    it.only('with callback returning an uninitialized value', async function () {
+      const receiver = await ethers.deployContract('ERC7984UnauthorizedReceiverMock', [this.token.target]);
+
+      await this.token
+        .connect(this.holder)
+        ['confidentialTransferAndCall(address,bytes32,bytes,bytes)'](
+          receiver.target,
+          this.encryptedInput.handles[0],
+          this.encryptedInput.inputProof,
+          '0x',
+        );
+
+      await expect(
+        fhevm.userDecryptEuint(
+          FhevmType.euint64,
+          await this.token.confidentialBalanceOf(this.holder),
+          this.token.target,
+          this.holder,
+        ),
+      ).to.eventually.equal(1000);
+    });
+
     it('with callback reverting without a reason', async function () {
       await expect(
         this.token

--- a/test/token/ERC7984/ERC7984.test.ts
+++ b/test/token/ERC7984/ERC7984.test.ts
@@ -487,7 +487,7 @@ describe('ERC7984', function () {
         .withArgs(unauthorizedRetval, maliciousReceiver.target);
     });
 
-    it.only('with callback returning an uninitialized value', async function () {
+    it('with callback returning an uninitialized value', async function () {
       const receiver = await ethers.deployContract('ERC7984UnauthorizedReceiverMock', [this.token.target]);
 
       await this.token


### PR DESCRIPTION
#428 disabled returning uninitialized handles. This a breaking change. This PR allows `IERC7984Receiver` to return unintialized handles (treated as a false boolean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Callback transfers now succeed when the receiver returns an uninitialized encrypted value.
  * Initialized encrypted callback results continue to require recipient authorization.
  * Unauthorized callback results still produce the expected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->