### PR TITLE
Harden ERC-1363 recipient decoding in `ERC7984ERC20Wrapper`

### DIFF
--- a/.changeset/brave-apples-decode.md
+++ b/.changeset/brave-apples-decode.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': minor
+---
+
+`ERC7984ERC20Wrapper`: Make ERC-1363 wrap recipient decoding strict (empty or exactly 20 packed bytes) and add overridable `_getOnTransferReceivedWrapRecipient`.

--- a/.changeset/brave-apples-decode.md
+++ b/.changeset/brave-apples-decode.md
@@ -2,4 +2,4 @@
 'openzeppelin-confidential-contracts': minor
 ---
 
-`ERC7984ERC20Wrapper`: Make ERC-1363 wrap recipient decoding strict (empty or exactly 20 packed bytes) and add overridable `_getOnTransferReceivedWrapRecipient`.
+`ERC7984ERC20Wrapper`: Make ERC-1363 wrap recipient decoding strict (empty or exactly 20 packed bytes) and add an overridable internal function `_getOnTransferReceivedWrapRecipient`.

--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -227,7 +227,7 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
         address /*operator*/,
         address from,
         uint256 /*amount*/,
-        bytes memory data
+        bytes calldata data
     ) internal view virtual returns (address) {
         uint256 length = data.length;
         if (length == 0) {

--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -67,7 +67,7 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
         require(underlying() == msg.sender, ERC7984UnauthorizedCaller(msg.sender));
 
         // mint confidential token
-        address to = _getOnTransferReceivedWrapRecipient(operator, from, amount, data);
+        address to = _getOnTransferReceivedWrapRecipient(operator, from, data);
         _wrap(to, amount);
 
         // transfer excess back to the sender
@@ -226,7 +226,6 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
     function _getOnTransferReceivedWrapRecipient(
         address /*operator*/,
         address from,
-        uint256 /*amount*/,
         bytes calldata data
     ) internal view virtual returns (address) {
         uint256 length = data.length;

--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -36,6 +36,7 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
 
     error InvalidUnwrapRequest(bytes32 unwrapRequestId);
     error ERC7984TotalSupplyOverflow();
+    error ERC7984InvalidTransferReceivedData();
 
     constructor(IERC20 underlying_) {
         _underlying = underlying_;
@@ -52,12 +53,12 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
     }
 
     /**
-     * @dev `ERC1363` callback function which wraps tokens to the address specified in `data` or
-     * the address `from` (if no address is specified in `data`). This function refunds any excess tokens
-     * sent beyond the nearest multiple of {rate} to `from`. See {wrap} for more details on wrapping tokens.
+     * @dev `ERC1363` callback function which wraps tokens to the address resolved by
+     * {_getOnTransferReceivedWrapRecipient}. This function refunds any excess tokens sent beyond the nearest
+     * multiple of {rate} to `from`. See {wrap} for more details on wrapping tokens.
      */
     function onTransferReceived(
-        address /*operator*/,
+        address operator,
         address from,
         uint256 amount,
         bytes calldata data
@@ -66,7 +67,7 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
         require(underlying() == msg.sender, ERC7984UnauthorizedCaller(msg.sender));
 
         // mint confidential token
-        address to = data.length < 20 ? from : address(bytes20(data));
+        address to = _getOnTransferReceivedWrapRecipient(operator, from, amount, data);
         _wrap(to, amount);
 
         // transfer excess back to the sender
@@ -211,6 +212,31 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
             _checkConfidentialTotalSupply();
         }
         return super._update(from, to, amount);
+    }
+
+    /**
+     * @dev Resolves the wrap recipient from an ERC-1363 `onTransferReceived` callback.
+     *
+     * Default encoding:
+     *
+     * * empty `data`: wrap to `from`
+     * * exactly 20 bytes: wrap to the recipient encoded in `data`
+     * * otherwise: revert with {ERC7984InvalidTransferReceivedData}
+     */
+    function _getOnTransferReceivedWrapRecipient(
+        address /*operator*/,
+        address from,
+        uint256 /*amount*/,
+        bytes memory data
+    ) internal virtual returns (address) {
+        uint256 length = data.length;
+        if (length == 0) {
+            return from;
+        }
+        if (length == 20) {
+            return address(bytes20(data));
+        }
+        revert ERC7984InvalidTransferReceivedData();
     }
 
     /**

--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -228,7 +228,7 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
         address from,
         uint256 /*amount*/,
         bytes memory data
-    ) internal virtual returns (address) {
+    ) internal view virtual returns (address) {
         uint256 length = data.length;
         if (length == 0) {
             return from;

--- a/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
@@ -196,6 +196,30 @@ describe('ERC7984ERC20Wrapper', function () {
             ).to.eventually.equal(ethers.parseUnits('100', 6));
           });
 
+          it('reverts with short transfer data', async function () {
+            const amountToWrap = ethers.parseUnits('100', 18);
+
+            await expect(
+              this.token
+                .connect(this.holder)
+                ['transferAndCall(address,uint256,bytes)'](this.wrapper, amountToWrap, '0x1234'),
+            ).to.be.revertedWithCustomError(this.wrapper, 'ERC7984InvalidTransferReceivedData');
+          });
+
+          it('reverts with abi-encoded transfer data', async function () {
+            const amountToWrap = ethers.parseUnits('100', 18);
+
+            await expect(
+              this.token
+                .connect(this.holder)
+                ['transferAndCall(address,uint256,bytes)'](
+                  this.wrapper,
+                  amountToWrap,
+                  ethers.AbiCoder.defaultAbiCoder().encode(['address'], [this.recipient.address]),
+                ),
+            ).to.be.revertedWithCustomError(this.wrapper, 'ERC7984InvalidTransferReceivedData');
+          });
+
           it('from unauthorized caller', async function () {
             await expect(this.wrapper.connect(this.holder).onTransferReceived(this.holder, this.holder, 100, '0x'))
               .to.be.revertedWithCustomError(this.wrapper, 'ERC7984UnauthorizedCaller')


### PR DESCRIPTION
Fixes #355

Harden ERC-1363 recipient decoding in `ERC7984ERC20Wrapper`. This PR requires that either the data is 0 or 20 bytes in length. This is enforced in an overridable `_getOnTransferReceivedWrapRecipient` internal function which returns the recipient address from the ERC-1363 context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced stricter recipient data validation when wrapping tokens through transfer callbacks.
  * Added clear error handling for invalid recipient data.
  * Added support for customizing recipient resolution through an overrideable hook.

* **Tests**
  * Added coverage for rejecting short and ABI-encoded transfer data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->