### PR TITLE
test: add happy-path test on cTransfer from uninitialized balance

### DIFF
--- a/test/token/ERC7984/ERC7984.test.ts
+++ b/test/token/ERC7984/ERC7984.test.ts
@@ -228,6 +228,23 @@ describe('ERC7984', function () {
 
         // Edge cases to run with sender as caller
         if (asSender) {
+          it('from address with no balance should pass', async function () {
+            const encryptedInput = await fhevm
+              .createEncryptedInput(this.token.target, this.recipient.address)
+              .add64(100)
+              .encrypt();
+
+            await expect(
+              this.token
+                .connect(this.recipient)
+                ['confidentialTransfer(address,bytes32,bytes)'](
+                  this.holder.address,
+                  encryptedInput.handles[0],
+                  encryptedInput.inputProof,
+                ),
+            ).to.not.be.reverted;
+          });
+
           it('to zero address', async function () {
             const encryptedInput = await fhevm
               .createEncryptedInput(this.token.target, this.holder.address)


### PR DESCRIPTION
following removal of error on confidential transfer from uninitialized balance: https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/pull/357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for confidential transfers submitted by accounts with no balance, ensuring the transaction does not revert unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->