### PR TITLE
Declare `GITHUB_TOKEN` permissions in workflows

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -14,6 +14,9 @@ concurrency:
   group: changeset-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,6 +13,9 @@ concurrency:
 env:
   MNEMONIC: "exchange vintage ocean narrow danger return culture ignore trim solve clock hidden buddy wise emotion"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
The product-security baseline rollout will set the repository default `GITHUB_TOKEN` permissions to **read-only** (with PR-approval by the token disabled). Workflows that rely on the current implicit write default would start failing at their next write operation. This PR makes each workflow's required permissions explicit so the downgrade is a no-op for this repo.

| Workflow | Declared permissions |
|---|---|
| `.github/workflows/changeset.yml` | `contents: read` |
| `.github/workflows/checks.yml` | `contents: read` |

Scopes were inferred from the actions and commands each workflow uses; read-only workflows get `contents: read`. Draft on purpose — please review before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows with read-only access to repository contents.
  * Improved workflow permission settings without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->