### PR TITLE
Prototype: encrypted spending limits for ERC-7984 operators

### DIFF
--- a/.changeset/olive-pianos-invite.md
+++ b/.changeset/olive-pianos-invite.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': minor
+---
+
+`ERC7984`: Add encrypted spending limits to operators. `setOperator` now takes an encrypted `limit` and its input proof, `isOperator` returns the remaining allowance alongside the approval status, and operator-initiated transfers are clamped to the remaining allowance and decrement it. An empty `limit` handle registers an unlimited operator. `ERC7984ERC20Wrapper`: Consume the operator allowance when unwrapping on behalf of a holder.

--- a/contracts/interfaces/IERC7984.sol
+++ b/contracts/interfaces/IERC7984.sol
@@ -11,7 +11,7 @@ interface IERC7984 is IERC165 {
      * @dev Emitted when the expiration timestamp for an operator `operator` is updated for a given `holder`.
      * The operator may move any amount of tokens on behalf of the holder until the timestamp `until`.
      */
-    event OperatorSet(address indexed holder, address indexed operator, uint48 until);
+    event OperatorSet(address indexed holder, address indexed operator, uint48 until, euint64 limit);
 
     /// @dev Emitted when a confidential transfer is made from `from` to `to` of encrypted amount `amount`.
     event ConfidentialTransfer(address indexed from, address indexed to, euint64 indexed amount);
@@ -43,14 +43,14 @@ interface IERC7984 is IERC165 {
     function confidentialBalanceOf(address account) external view returns (euint64);
 
     /// @dev Returns true if `spender` is currently an operator for `holder`.
-    function isOperator(address holder, address spender) external view returns (bool);
+    function isOperator(address holder, address spender) external view returns (bool, euint64);
 
     /**
      * @dev Sets `operator` as an operator for `holder` until the timestamp `until`.
      *
      * NOTE: An operator may transfer any amount of tokens on behalf of a holder while approved.
      */
-    function setOperator(address operator, uint48 until) external;
+    function setOperator(address operator, uint48 until, externalEuint64 limit, bytes calldata inputProof) external;
 
     /**
      * @dev Transfers the encrypted amount `encryptedAmount` to `to` with the given input proof `inputProof`.

--- a/contracts/interfaces/IERC7984.sol
+++ b/contracts/interfaces/IERC7984.sol
@@ -42,13 +42,19 @@ interface IERC7984 is IERC165 {
     /// @dev Returns the confidential balance of the account `account`.
     function confidentialBalanceOf(address account) external view returns (euint64);
 
-    /// @dev Returns true if `spender` is currently an operator for `holder`.
+    /**
+     * @dev Returns whether `spender` is currently an operator for `holder`, along with its remaining encrypted
+     * spending allowance. An uninitialized allowance means the operator is not constrained by a limit.
+     */
     function isOperator(address holder, address spender) external view returns (bool, euint64);
 
     /**
-     * @dev Sets `operator` as an operator for `holder` until the timestamp `until`.
+     * @dev Sets `operator` as an operator for `holder` until the timestamp `until`, with `limit` as its encrypted
+     * spending allowance. The allowance is consumed by the transfers the operator initiates, and a transfer that
+     * exceeds the remaining allowance moves nothing.
      *
-     * NOTE: An operator may transfer any amount of tokens on behalf of a holder while approved.
+     * NOTE: Passing an empty `limit` handle sets an unlimited operator, which may transfer any amount of tokens on
+     * behalf of the holder while approved.
      */
     function setOperator(address operator, uint48 until, externalEuint64 limit, bytes calldata inputProof) external;
 

--- a/contracts/mocks/docs/SwapERC7984ToERC7984.sol
+++ b/contracts/mocks/docs/SwapERC7984ToERC7984.sol
@@ -11,7 +11,8 @@ contract SwapERC7984ToERC7984 {
         externalEuint64 amountInput,
         bytes calldata inputProof
     ) public virtual {
-        require(fromToken.isOperator(msg.sender, address(this)));
+        (bool isOperator, ) = fromToken.isOperator(msg.sender, address(this));
+        require(isOperator);
 
         euint64 amount = FHE.fromExternal(amountInput, inputProof);
 

--- a/contracts/token/ERC7984/ERC7984.sol
+++ b/contracts/token/ERC7984/ERC7984.sol
@@ -120,7 +120,12 @@ abstract contract ERC7984 is IERC7984, ERC165 {
         externalEuint64 limit,
         bytes calldata inputProof
     ) public virtual {
-        _setOperator(msg.sender, operator, until, FHE.fromExternal(limit, inputProof));
+        _setOperator(
+            msg.sender,
+            operator,
+            until,
+            externalEuint64.unwrap(limit) == bytes32(0) ? euint64.wrap(0) : FHE.fromExternal(limit, inputProof)
+        );
     }
 
     /// @inheritdoc IERC7984
@@ -246,11 +251,19 @@ abstract contract ERC7984 is IERC7984, ERC165 {
         emit AmountDisclosed(encryptedAmount, cleartextAmount);
     }
 
+    /**
+     * @dev Registers `operator` as an operator of `holder` until `until`, with an encrypted spending allowance.
+     *
+     * An uninitialized `limit` means the operator is unlimited. Uninitialized handles cannot be granted through the
+     * ACL, so the allowances are only set for an actual limit.
+     */
     function _setOperator(address holder, address operator, uint48 until, euint64 limit) internal virtual {
         _operators[holder][operator] = OperatorDetails({until: until, limit: limit});
-        FHE.allowThis(limit);
-        FHE.allow(limit, holder);
-        FHE.allow(limit, operator);
+        if (FHE.isInitialized(limit)) {
+            FHE.allowThis(limit);
+            FHE.allow(limit, holder);
+            FHE.allow(limit, operator);
+        }
         emit OperatorSet(holder, operator, until, limit);
     }
 

--- a/contracts/token/ERC7984/ERC7984.sol
+++ b/contracts/token/ERC7984/ERC7984.sol
@@ -25,8 +25,13 @@ import {ERC7984Utils} from "./utils/ERC7984Utils.sol";
  * - Safe overflow/underflow handling for FHE operations
  */
 abstract contract ERC7984 is IERC7984, ERC165 {
+    struct OperatorDetails {
+        uint48 until;
+        euint64 limit;
+    }
+
     mapping(address holder => euint64) private _balances;
-    mapping(address holder => mapping(address spender => uint48)) private _operators;
+    mapping(address holder => mapping(address spender => OperatorDetails)) private _operators;
     euint64 private _totalSupply;
     string private _name;
     string private _symbol;
@@ -96,16 +101,26 @@ abstract contract ERC7984 is IERC7984, ERC165 {
     }
 
     /// @inheritdoc IERC7984
-    function isOperator(address holder, address spender) public view virtual returns (bool) {
-        return holder == spender || block.timestamp <= _operators[holder][spender];
+    function isOperator(address holder, address spender) public view virtual returns (bool success, euint64 limit) {
+        if (holder == spender) {
+            return (true, euint64.wrap(0));
+        } else {
+            OperatorDetails memory details = _operators[holder][spender];
+            return (details.until >= block.timestamp, details.limit);
+        }
     }
 
     /**
      * @dev See {IERC7984-setOperator}. Operators are given ACL allowance (ability to decrypt) for the transferred amount
      * of transfers they initiate.
      */
-    function setOperator(address operator, uint48 until) public virtual {
-        _setOperator(msg.sender, operator, until);
+    function setOperator(
+        address operator,
+        uint48 until,
+        externalEuint64 limit,
+        bytes calldata inputProof
+    ) public virtual {
+        _setOperator(msg.sender, operator, until, FHE.fromExternal(limit, inputProof));
     }
 
     /// @inheritdoc IERC7984
@@ -130,8 +145,11 @@ abstract contract ERC7984 is IERC7984, ERC165 {
         externalEuint64 encryptedAmount,
         bytes calldata inputProof
     ) public virtual returns (euint64) {
-        require(isOperator(from, msg.sender), ERC7984UnauthorizedSpender(from, msg.sender));
-        euint64 transferred = _transfer(from, to, FHE.fromExternal(encryptedAmount, inputProof));
+        euint64 transferred = _transfer(
+            from,
+            to,
+            _consumeOperatorAllowance(from, msg.sender, FHE.fromExternal(encryptedAmount, inputProof))
+        );
         FHE.allowTransient(transferred, msg.sender);
         return transferred;
     }
@@ -139,8 +157,7 @@ abstract contract ERC7984 is IERC7984, ERC165 {
     /// @inheritdoc IERC7984
     function confidentialTransferFrom(address from, address to, euint64 amount) public virtual returns (euint64) {
         require(FHE.isAllowed(amount, msg.sender), ERC7984UnauthorizedUseOfEncryptedAmount(amount, msg.sender));
-        require(isOperator(from, msg.sender), ERC7984UnauthorizedSpender(from, msg.sender));
-        euint64 transferred = _transfer(from, to, amount);
+        euint64 transferred = _transfer(from, to, _consumeOperatorAllowance(from, msg.sender, amount));
         FHE.allowTransient(transferred, msg.sender);
         return transferred;
     }
@@ -173,8 +190,13 @@ abstract contract ERC7984 is IERC7984, ERC165 {
         bytes calldata inputProof,
         bytes calldata data
     ) public virtual returns (euint64) {
-        require(isOperator(from, msg.sender), ERC7984UnauthorizedSpender(from, msg.sender));
-        return _transferAndCall(from, to, FHE.fromExternal(encryptedAmount, inputProof), data);
+        return
+            _transferAndCall(
+                from,
+                to,
+                _consumeOperatorAllowance(from, msg.sender, FHE.fromExternal(encryptedAmount, inputProof)),
+                data
+            );
     }
 
     /// @inheritdoc IERC7984
@@ -185,8 +207,7 @@ abstract contract ERC7984 is IERC7984, ERC165 {
         bytes calldata data
     ) public virtual returns (euint64) {
         require(FHE.isAllowed(amount, msg.sender), ERC7984UnauthorizedUseOfEncryptedAmount(amount, msg.sender));
-        require(isOperator(from, msg.sender), ERC7984UnauthorizedSpender(from, msg.sender));
-        return _transferAndCall(from, to, amount, data);
+        return _transferAndCall(from, to, _consumeOperatorAllowance(from, msg.sender, amount), data);
     }
 
     /**
@@ -225,9 +246,33 @@ abstract contract ERC7984 is IERC7984, ERC165 {
         emit AmountDisclosed(encryptedAmount, cleartextAmount);
     }
 
-    function _setOperator(address holder, address operator, uint48 until) internal virtual {
-        _operators[holder][operator] = until;
-        emit OperatorSet(holder, operator, until);
+    function _setOperator(address holder, address operator, uint48 until, euint64 limit) internal virtual {
+        _operators[holder][operator] = OperatorDetails({until: until, limit: limit});
+        FHE.allowThis(limit);
+        FHE.allow(limit, holder);
+        FHE.allow(limit, operator);
+        emit OperatorSet(holder, operator, until, limit);
+    }
+
+    function _consumeOperatorAllowance(
+        address holder,
+        address operator,
+        euint64 amount
+    ) internal virtual returns (euint64) {
+        (bool success, euint64 limit) = isOperator(holder, operator);
+        require(success, ERC7984UnauthorizedSpender(holder, operator));
+
+        if (!FHE.isInitialized(limit)) {
+            return amount;
+        } else {
+            euint64 consumed = FHE.select(FHE.le(amount, limit), amount, FHE.asEuint64(0));
+            euint64 newLimit = FHE.sub(limit, consumed);
+            _operators[holder][operator].limit = newLimit;
+            FHE.allowThis(newLimit);
+            FHE.allow(newLimit, holder);
+            FHE.allow(newLimit, operator);
+            return consumed;
+        }
     }
 
     function _mint(address to, euint64 amount) internal returns (euint64 transferred) {

--- a/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -252,10 +252,9 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
     /// @dev Internal logic for handling the creation of unwrap requests. Returns the unwrap request id.
     function _unwrap(address from, address to, euint64 amount) internal virtual returns (bytes32) {
         require(to != address(0), ERC7984InvalidReceiver(to));
-        require(from == msg.sender || isOperator(from, msg.sender), ERC7984UnauthorizedSpender(from, msg.sender));
 
         // try to burn, see how much we actually got
-        euint64 unwrapAmount_ = _burn(from, amount);
+        euint64 unwrapAmount_ = _burn(from, _consumeOperatorAllowance(from, msg.sender, amount));
         FHE.makePubliclyDecryptable(unwrapAmount_);
 
         assert(unwrapRequester(euint64.unwrap(unwrapAmount_)) == address(0));

--- a/test/finance/BatcherConfidential.test.ts
+++ b/test/finance/BatcherConfidential.test.ts
@@ -1,6 +1,7 @@
 import { BatcherConfidentialSwapMock } from '../../types';
 import { $ERC20Mock } from '../../types/contracts-exposed/mocks/token/ERC20Mock.sol/$ERC20Mock';
 import { $ERC7984ERC20Wrapper } from '../../types/contracts-exposed/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol/$ERC7984ERC20Wrapper';
+import { setOperator } from '../helpers/erc7984';
 import { FhevmType } from '@fhevm/hardhat-plugin';
 import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
@@ -87,7 +88,7 @@ describe('BatcherConfidential', function () {
     ]);
 
     for (const approver of [holder, recipient]) {
-      await fromToken.connect(approver).setOperator(batcher, 2n ** 48n - 1n);
+      await setOperator(fromToken, approver, batcher, 2n ** 48n - 1n);
     }
 
     Object.assign(this, {
@@ -733,7 +734,7 @@ describe('BatcherConfidential', function () {
       ethers.ZeroAddress, // no need for an exchange in this test
       this.operator,
     ]);
-    await this.fromToken.connect(this.holder).setOperator(batcher, 2n ** 48n - 1n);
+    await setOperator(this.fromToken, this.holder, batcher, 2n ** 48n - 1n);
 
     // ========================== First batch ==========================
     const batchId1 = await batcher.currentBatchId();

--- a/test/finance/VestingWalletConfidentialFactory.test.ts
+++ b/test/finance/VestingWalletConfidentialFactory.test.ts
@@ -1,5 +1,6 @@
 import { $VestingWalletConfidentialFactoryMock } from '../../types/contracts-exposed/mocks/finance/VestingWalletConfidentialFactoryMock.sol/$VestingWalletConfidentialFactoryMock';
 import { $ERC7984Mock } from '../../types/contracts-exposed/mocks/token/ERC7984/ERC7984Mock.sol/$ERC7984Mock';
+import { MAX_OPERATOR_LIMIT } from '../helpers/erc7984';
 import { FhevmType } from '@fhevm/hardhat-plugin';
 import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
@@ -35,9 +36,17 @@ describe('VestingWalletCliffExecutorConfidentialFactory', function () {
       .connect(holder)
       ['$_mint(address,bytes32,bytes)'](holder.address, encryptedInput.handles[0], encryptedInput.inputProof);
     const until = (await time.latest()) + days(1);
-    await expect(await token.connect(holder).setOperator(await factory.getAddress(), until))
+    const limitInput = await fhevm
+      .createEncryptedInput(await token.getAddress(), holder.address)
+      .add64(MAX_OPERATOR_LIMIT)
+      .encrypt();
+    await expect(
+      await token
+        .connect(holder)
+        .setOperator(await factory.getAddress(), until, limitInput.handles[0], limitInput.inputProof),
+    )
       .to.emit(token, 'OperatorSet')
-      .withArgs(holder, await factory.getAddress(), until);
+      .withArgs(holder, await factory.getAddress(), until, ethers.hexlify(limitInput.handles[0]));
 
     Object.assign(this, {
       accounts,

--- a/test/finance/VestingWalletConfidentialFactory.test.ts
+++ b/test/finance/VestingWalletConfidentialFactory.test.ts
@@ -1,6 +1,6 @@
 import { $VestingWalletConfidentialFactoryMock } from '../../types/contracts-exposed/mocks/finance/VestingWalletConfidentialFactoryMock.sol/$VestingWalletConfidentialFactoryMock';
 import { $ERC7984Mock } from '../../types/contracts-exposed/mocks/token/ERC7984/ERC7984Mock.sol/$ERC7984Mock';
-import { MAX_OPERATOR_LIMIT } from '../helpers/erc7984';
+import { setOperator } from '../helpers/erc7984';
 import { FhevmType } from '@fhevm/hardhat-plugin';
 import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
@@ -36,17 +36,9 @@ describe('VestingWalletCliffExecutorConfidentialFactory', function () {
       .connect(holder)
       ['$_mint(address,bytes32,bytes)'](holder.address, encryptedInput.handles[0], encryptedInput.inputProof);
     const until = (await time.latest()) + days(1);
-    const limitInput = await fhevm
-      .createEncryptedInput(await token.getAddress(), holder.address)
-      .add64(MAX_OPERATOR_LIMIT)
-      .encrypt();
-    await expect(
-      await token
-        .connect(holder)
-        .setOperator(await factory.getAddress(), until, limitInput.handles[0], limitInput.inputProof),
-    )
+    await expect(await setOperator(token, holder, await factory.getAddress(), until))
       .to.emit(token, 'OperatorSet')
-      .withArgs(holder, await factory.getAddress(), until, ethers.hexlify(limitInput.handles[0]));
+      .withArgs(holder, await factory.getAddress(), until, ethers.ZeroHash);
 
     Object.assign(this, {
       accounts,

--- a/test/helpers/erc7984.ts
+++ b/test/helpers/erc7984.ts
@@ -1,0 +1,21 @@
+import { Addressable, Signer, resolveAddress } from 'ethers';
+import { fhevm } from 'hardhat';
+
+/// Largest limit an `euint64` allowance can hold, used when a test does not care about the operator limit.
+export const MAX_OPERATOR_LIMIT = 2n ** 64n - 1n;
+
+/// Encrypts `limit` and registers `operator` as an operator of `holder` until `until`.
+export async function setOperator(
+  token: any,
+  holder: Signer,
+  operator: string | Addressable,
+  until: bigint | number,
+  limit: bigint | number = MAX_OPERATOR_LIMIT,
+) {
+  const input = await fhevm
+    .createEncryptedInput(await resolveAddress(token), await holder.getAddress())
+    .add64(limit)
+    .encrypt();
+
+  return token.connect(holder).setOperator(operator, until, input.handles[0], input.inputProof);
+}

--- a/test/helpers/erc7984.ts
+++ b/test/helpers/erc7984.ts
@@ -1,21 +1,20 @@
-import { Addressable, Signer, resolveAddress } from 'ethers';
+import { AddressLike, Signer, ZeroHash, resolveAddress } from 'ethers';
 import { fhevm } from 'hardhat';
 
-/// Largest limit an `euint64` allowance can hold, used when a test does not care about the operator limit.
-export const MAX_OPERATOR_LIMIT = 2n ** 64n - 1n;
-
-/// Encrypts `limit` and registers `operator` as an operator of `holder` until `until`.
+/// Registers `operator` as an operator of `holder` until `until`, encrypting `limit` when one is given.
+/// Omitting `limit` sends the empty handle, which registers an unlimited operator.
 export async function setOperator(
-  token: any,
+  token: any, // ethers.Contract (that implement ERC7984)
   holder: Signer,
-  operator: string | Addressable,
+  operator: AddressLike,
   until: bigint | number,
-  limit: bigint | number = MAX_OPERATOR_LIMIT,
+  limit?: bigint | number,
 ) {
-  const input = await fhevm
-    .createEncryptedInput(await resolveAddress(token), await holder.getAddress())
-    .add64(limit)
-    .encrypt();
+  const input = await (limit === undefined
+    ? Promise.resolve({ handles: [ZeroHash], inputProof: '0x' })
+    : Promise.all([resolveAddress(token), holder.getAddress()]).then(([tokenAddress, holderAddress]) =>
+        fhevm.createEncryptedInput(tokenAddress, holderAddress).add64(limit).encrypt(),
+      ));
 
   return token.connect(holder).setOperator(operator, until, input.handles[0], input.inputProof);
 }

--- a/test/helpers/interface.ts
+++ b/test/helpers/interface.ts
@@ -19,7 +19,7 @@ export const SIGNATURES = {
     'decimals()',
     'isOperator(address,address)',
     'name()',
-    'setOperator(address,uint48)',
+    'setOperator(address,uint48,bytes32,bytes)',
     'symbol()',
   ],
   ERC7984ERC20Wrapper: [

--- a/test/token/ERC7984/ERC7984.behavior.ts
+++ b/test/token/ERC7984/ERC7984.behavior.ts
@@ -81,6 +81,107 @@ function shouldBehaveLikeERC7984(name: string, symbol: string, uri: string, deci
       });
     });
 
+    describe('operator limit', function () {
+      const until = 2n ** 48n - 1n;
+
+      // Transfers `amount` from the holder to the recipient, as the operator.
+      const transferFrom = async function (this: any, amount: number) {
+        const input = await fhevm
+          .createEncryptedInput(await this.token.getAddress(), this.operator.address)
+          .add64(amount)
+          .encrypt();
+
+        return this.token
+          .connect(this.operator)
+          ['confidentialTransferFrom(address,address,bytes32,bytes)'](
+            this.holder,
+            this.recipient,
+            input.handles[0],
+            input.inputProof,
+          );
+      };
+
+      const decrypt = async function (this: any, handle: string, account: any) {
+        return fhevm.userDecryptEuint(FhevmType.euint64, handle, await this.token.getAddress(), account);
+      };
+
+      describe('without a limit', function () {
+        beforeEach(async function () {
+          await setOperator(this.token, this.holder, this.operator.address, until);
+        });
+
+        it('registers an uninitialized limit', async function () {
+          await expect(this.token.isOperator(this.holder, this.operator)).to.eventually.deep.equal([
+            true,
+            ethers.ZeroHash,
+          ]);
+        });
+
+        it('does not constrain the operator', async function () {
+          await transferFrom.call(this, 600);
+          await transferFrom.call(this, 400);
+
+          await expect(
+            decrypt.call(this, await this.token.confidentialBalanceOf(this.recipient), this.recipient),
+          ).to.eventually.equal(1000);
+          await expect(this.token.isOperator(this.holder, this.operator)).to.eventually.deep.equal([
+            true,
+            ethers.ZeroHash,
+          ]);
+        });
+      });
+
+      describe('with a limit', function () {
+        beforeEach(async function () {
+          await setOperator(this.token, this.holder, this.operator.address, until, 300);
+        });
+
+        it('limit is decryptable by the holder and the operator', async function () {
+          const [, limit] = await this.token.isOperator(this.holder, this.operator);
+
+          await expect(decrypt.call(this, limit, this.holder)).to.eventually.equal(300);
+          await expect(decrypt.call(this, limit, this.operator)).to.eventually.equal(300);
+          await expect(decrypt.call(this, limit, this.anyone)).to.be.rejectedWith(
+            generateDecryptionErrorMessage(limit, this.anyone.address),
+          );
+        });
+
+        it('a transfer within the limit consumes it', async function () {
+          await transferFrom.call(this, 100);
+
+          await expect(
+            decrypt.call(this, await this.token.confidentialBalanceOf(this.recipient), this.recipient),
+          ).to.eventually.equal(100);
+
+          const [, limit] = await this.token.isOperator(this.holder, this.operator);
+          await expect(decrypt.call(this, limit, this.holder)).to.eventually.equal(200);
+        });
+
+        it('the limit is consumed across transfers', async function () {
+          await transferFrom.call(this, 100);
+          await transferFrom.call(this, 200);
+
+          await expect(
+            decrypt.call(this, await this.token.confidentialBalanceOf(this.recipient), this.recipient),
+          ).to.eventually.equal(300);
+
+          const [, limit] = await this.token.isOperator(this.holder, this.operator);
+          await expect(decrypt.call(this, limit, this.holder)).to.eventually.equal(0);
+        });
+
+        it('a transfer over the limit moves nothing and leaves the limit untouched', async function () {
+          await transferFrom.call(this, 301);
+
+          await expect(
+            decrypt.call(this, await this.token.confidentialBalanceOf(this.holder), this.holder),
+          ).to.eventually.equal(1000);
+
+          const [, limit] = await this.token.isOperator(this.holder, this.operator);
+          await expect(decrypt.call(this, limit, this.holder)).to.eventually.equal(300);
+        });
+      });
+    });
+
     describe('transfer', function () {
       for (const asSender of [true, false]) {
         describe(asSender ? 'as sender' : 'as operator', function () {

--- a/test/token/ERC7984/ERC7984.behavior.ts
+++ b/test/token/ERC7984/ERC7984.behavior.ts
@@ -1,4 +1,5 @@
 import { allowHandle } from '../../helpers/accounts';
+import { setOperator } from '../../helpers/erc7984';
 import { INTERFACE_IDS, INVALID_ID } from '../../helpers/interface';
 import { FhevmType } from '@fhevm/hardhat-plugin';
 import { expect } from 'chai';
@@ -86,7 +87,7 @@ function shouldBehaveLikeERC7984(name: string, symbol: string, uri: string, deci
           beforeEach(async function () {
             if (!asSender) {
               const timestamp = (await ethers.provider.getBlock('latest'))!.timestamp + 100;
-              await this.token.connect(this.holder).setOperator(this.operator.address, timestamp);
+              await setOperator(this.token, this.holder, this.operator.address, timestamp);
             }
           });
 
@@ -111,7 +112,7 @@ function shouldBehaveLikeERC7984(name: string, symbol: string, uri: string, deci
                 });
 
                 it('without operator approval should fail', async function () {
-                  await this.token.$_setOperator(this.holder, this.operator, 0);
+                  await setOperator(this.token, this.holder, this.operator.address, 0);
 
                   await expect(
                     this.token
@@ -327,7 +328,7 @@ function shouldBehaveLikeERC7984(name: string, symbol: string, uri: string, deci
             if (usingTransferFrom) {
               describe('without operator approval', function () {
                 beforeEach(async function () {
-                  await this.token.connect(this.holder).setOperator(this.operator.address, 0);
+                  await setOperator(this.token, this.holder, this.operator.address, 0);
                   await allowHandle(
                     hre,
                     this.holder,

--- a/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984ERC20Wrapper.test.ts
@@ -1,4 +1,5 @@
 import { ERC7984ERC20WrapperMock } from '../../../../types';
+import { setOperator } from '../../../helpers/erc7984';
 import { INTERFACE_IDS, INVALID_ID } from '../../../helpers/interface';
 import { shouldBehaveLikeERC7984 } from '../ERC7984.behavior';
 import { FhevmType } from '@fhevm/hardhat-plugin';
@@ -322,7 +323,7 @@ describe('ERC7984ERC20Wrapper', function () {
         .add64(withdrawalAmount)
         .encrypt();
 
-      await this.wrapper.connect(this.holder).setOperator(this.operator.address, (await time.latest()) + 1000);
+      await setOperator(this.wrapper, this.holder, this.operator.address, (await time.latest()) + 1000);
 
       await this.wrapper
         .connect(this.operator)

--- a/test/token/ERC7984/extensions/ERC7984Omnibus.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984Omnibus.test.ts
@@ -1,6 +1,7 @@
 import { IACL__factory } from '../../../../types';
 import { $ERC7984OmnibusMock } from '../../../../types/contracts-exposed/mocks/token/ERC7984/extensions/ERC7984OmnibusMock.sol/$ERC7984OmnibusMock';
 import { getAclAddress } from '../../../helpers/accounts';
+import { setOperator } from '../../../helpers/erc7984';
 import { shouldBehaveLikeERC7984 } from '../ERC7984.behavior';
 import { FhevmType } from '@fhevm/hardhat-plugin';
 import { expect } from 'chai';
@@ -33,7 +34,7 @@ describe('ERC7984Omnibus', function () {
             describe(withProof ? 'with transfer proof' : 'without transfer proof', function () {
               beforeEach(async function () {
                 if (transferFrom) {
-                  await this.token.connect(this.holder).setOperator(this.operator.address, 999999999999);
+                  await setOperator(this.token, this.holder, this.operator.address, 999999999999);
                 }
               });
 

--- a/test/token/ERC7984/extensions/ERC7984Restricted.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984Restricted.test.ts
@@ -1,6 +1,7 @@
 const { ethers, fhevm } = require('hardhat');
 const { expect } = require('chai');
 const { shouldBehaveLikeERC7984 } = require('../ERC7984.behavior');
+const { setOperator } = require('../../../helpers/erc7984');
 
 const name = 'token';
 const symbol = 'tk';
@@ -112,7 +113,7 @@ describe('ERC7984Restricted', function () {
 
       beforeEach(async function () {
         const timestamp = (await ethers.provider.getBlock('latest')).timestamp;
-        await this.token.connect(this.holder).setOperator(this.approved, timestamp + 1000);
+        await setOperator(this.token, this.holder, this.approved, timestamp + 1000);
 
         // Create encrypted input for the transfer amount
         encryptedInput = await fhevm


### PR DESCRIPTION
Prototype of encrypted, per-operator spending limits.

## What changed

- `setOperator(operator, until, limit, inputProof)` registers an encrypted `euint64` allowance alongside the expiration. `OperatorSet` carries the limit.
- `isOperator(holder, spender)` returns `(bool, euint64)`. An **uninitialized** limit handle is the "unlimited" sentinel — it is what `holder == spender` returns, and what an empty `limit` handle registers. Unlimited operators cost no FHE ops on transfer.
- Every operator-driven path (`confidentialTransferFrom`, `confidentialTransferFromAndCall`, both overloads of each) routes the amount through the new `_consumeOperatorAllowance`, which clamps to the remaining limit and decrements it.
- `ERC7984ERC20Wrapper._unwrap` uses the same helper, so unwrapping through an operator consumes the limit too. This replaces its `from == msg.sender || isOperator(...)` check.
- Tests: a `setOperator` helper that encrypts the limit (empty handle when none is given), plus an `operator limit` block in `ERC7984.behavior.ts` — so it runs against every ERC-7984 variant — covering the unlimited path, decryption rights on the limit, consumption within and across transfers, and over-limit transfers. 664 passing.

## Open questions

- **Two quiet failure modes in one function.** Dropping the input proof (empty handle) grants *unlimited* spend rather than reverting, and an over-limit transfer moves nothing while returning a handle and reverting nothing. The latter is consistent with how insufficient balance behaves elsewhere in the codebase; the former is new. Alternative considered: no sentinel, `type(uint64).max` as the unlimited value — safer, but costs a `select` + `sub` on every operator transfer including unlimited ones.
- **Breaking interface change.** `isOperator`'s return type changes the ERC-7984 interface id, and `setOperator` gains two parameters. The draft ERC needs to move with this.
- **Storage.** `OperatorDetails` is `uint48` + `euint64` (a `bytes32` UDVT), so operator records go from one slot to two, paid by every holder/operator pair including unlimited ones.
- **Per-transfer cost for limited operators.** Each consume adds `le` + `select` + `sub` and rewrites three ACL grants for the new limit handle. Worth deciding whether the holder and the operator both need standing decryption rights on every intermediate limit.
- **Wrapper scope.** Making `_unwrap` consume the allowance is a judgment call — it can stay a plain operator check if limits should be scoped to transfers only.
