### PR TITLE
Revert in `ERC7984._setOperator` when the holder is its own operator

### DIFF
--- a/.changeset/tidy-moons-judge.md
+++ b/.changeset/tidy-moons-judge.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': minor
+---
+
+`ERC7984`: Revert in `_setOperator` when the holder is set as its own operator. A holder always has unrestricted access to its own tokens, and that cannot be restricted.

--- a/.changeset/tidy-moons-judge.md
+++ b/.changeset/tidy-moons-judge.md
@@ -2,4 +2,4 @@
 'openzeppelin-confidential-contracts': minor
 ---
 
-`ERC7984`: Revert in `_setOperator` when the holder is set as its own operator. A holder always has unrestricted access to its own tokens, and that cannot be restricted.
+`ERC7984`: Revert in `_setOperator` when the holder or `address(0)` is set as the operator.

--- a/contracts/token/ERC7984/ERC7984.sol
+++ b/contracts/token/ERC7984/ERC7984.sol
@@ -44,6 +44,9 @@ abstract contract ERC7984 is IERC7984, ERC165 {
     /// @dev The given holder `holder` is not authorized to spend on behalf of `spender`.
     error ERC7984UnauthorizedSpender(address holder, address spender);
 
+    /// @dev The given operator `operator` is invalid.
+    error ERC7984InvalidOperator(address operator);
+
     /**
      * @dev The caller `user` does not have access to the encrypted amount `amount`.
      *
@@ -225,7 +228,14 @@ abstract contract ERC7984 is IERC7984, ERC165 {
         emit AmountDisclosed(encryptedAmount, cleartextAmount);
     }
 
+    /**
+     * @dev Sets the operator status of `operator` for `holder` until `until`.
+     *
+     * NOTE: A holder is always an operator of itself and has unrestricted access to its own tokens. That cannot be
+     * changed, therefore setting `holder` as its own operator reverts.
+     */
     function _setOperator(address holder, address operator, uint48 until) internal virtual {
+        require(holder != operator, ERC7984InvalidOperator(operator));
         _operators[holder][operator] = until;
         emit OperatorSet(holder, operator, until);
     }

--- a/contracts/token/ERC7984/ERC7984.sol
+++ b/contracts/token/ERC7984/ERC7984.sol
@@ -235,7 +235,7 @@ abstract contract ERC7984 is IERC7984, ERC165 {
      * changed, therefore setting `holder` as its own operator reverts.
      */
     function _setOperator(address holder, address operator, uint48 until) internal virtual {
-        require(holder != operator, ERC7984InvalidOperator(operator));
+        require(holder != operator && operator != address(0), ERC7984InvalidOperator(operator));
         _operators[holder][operator] = until;
         emit OperatorSet(holder, operator, until);
     }

--- a/test/token/ERC7984/ERC7984.behavior.ts
+++ b/test/token/ERC7984/ERC7984.behavior.ts
@@ -80,6 +80,30 @@ function shouldBehaveLikeERC7984(name: string, symbol: string, uri: string, deci
       });
     });
 
+    describe('setOperator', function () {
+      it('sets the operator', async function () {
+        const timestamp = (await ethers.provider.getBlock('latest'))!.timestamp + 100;
+
+        await expect(this.token.connect(this.holder).setOperator(this.operator, timestamp))
+          .to.emit(this.token, 'OperatorSet')
+          .withArgs(this.holder.address, this.operator.address, timestamp);
+
+        await expect(this.token.isOperator(this.holder, this.operator)).to.eventually.be.true;
+      });
+
+      it('holder is its own operator', async function () {
+        await expect(this.token.isOperator(this.holder, this.holder)).to.eventually.be.true;
+      });
+
+      it('reverts when holder is the operator', async function () {
+        const timestamp = (await ethers.provider.getBlock('latest'))!.timestamp + 100;
+
+        await expect(this.token.connect(this.holder).setOperator(this.holder, timestamp))
+          .to.be.revertedWithCustomError(this.token, 'ERC7984InvalidOperator')
+          .withArgs(this.holder.address);
+      });
+    });
+
     describe('transfer', function () {
       for (const asSender of [true, false]) {
         describe(asSender ? 'as sender' : 'as operator', function () {

--- a/test/token/ERC7984/ERC7984.behavior.ts
+++ b/test/token/ERC7984/ERC7984.behavior.ts
@@ -102,6 +102,12 @@ function shouldBehaveLikeERC7984(name: string, symbol: string, uri: string, deci
           .to.be.revertedWithCustomError(this.token, 'ERC7984InvalidOperator')
           .withArgs(this.holder.address);
       });
+
+      it('reverts when operator is the zero address', async function () {
+        await expect(this.token.connect(this.holder).setOperator(ethers.ZeroAddress, 0))
+          .to.be.revertedWithCustomError(this.token, 'ERC7984InvalidOperator')
+          .withArgs(ethers.ZeroAddress);
+      });
     });
 
     describe('transfer', function () {


### PR DESCRIPTION
`isOperator(holder, holder)` is unconditionally `true`: a holder has unrestricted access to its own tokens. Since that relation cannot be restricted, storing an operator expiry for `holder == operator` is meaningless (and misleading, as it emits an `OperatorSet` event that suggests the access is time bounded).

`_setOperator` now reverts with a new `ERC7984InvalidOperator(address operator)` error in that case.

Tests for `setOperator` are added to `ERC7984.behavior.ts`, so they run on all `ERC7984` variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented holders from assigning themselves as operators; such attempts now revert with an error.
  * Confirmed that valid operator assignments and authorization events continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->