### PR TITLE
Pass the transfer `operator` to `ERC7984Hooked` pre/post transfer hooks

### DIFF
--- a/.changeset/tall-donuts-shave.md
+++ b/.changeset/tall-donuts-shave.md
@@ -1,0 +1,5 @@
+---
+'openzeppelin-confidential-contracts': minor
+---
+
+`ERC7984Hooked`: Pass the transfer's `operator` (the `msg.sender` that initiated the update) to the pre- and post-transfer hooks. `IERC7984HookModule.preTransfer` and `IERC7984HookModule.postTransfer` now take an additional leading `operator` argument, and `ERC7984HookModule._preTransfer` / `_postTransfer` receive it after `token`.

--- a/contracts/interfaces/IERC7984HookModule.sol
+++ b/contracts/interfaces/IERC7984HookModule.sol
@@ -21,11 +21,15 @@ interface IERC7984HookModule is IERC165 {
     /**
      * @dev Hook that runs before a transfer. Should not mutate token state. Module is already
      * granted transient access to `encryptedAmount`.
+     *
+     * `operator` is the address that initiated the transfer on the token. It is equal to `from` for
+     * direct transfers, and differs from it when the transfer is initiated by an approved operator or
+     * by the token itself (e.g. mints, burns and forced transfers).
      */
-    function preTransfer(address from, address to, euint64 encryptedAmount) external returns (ebool);
+    function preTransfer(address operator, address from, address to, euint64 encryptedAmount) external returns (ebool);
 
-    /// @dev Performs operation after transfer.
-    function postTransfer(address from, address to, euint64 encryptedAmount) external;
+    /// @dev Performs operation after transfer. See {preTransfer} for the meaning of `operator`.
+    function postTransfer(address operator, address from, address to, euint64 encryptedAmount) external;
 
     /// @dev Performs operations after installation.
     function onInstall(bytes calldata initData) external;

--- a/contracts/mocks/token/ERC7984/ERC7984MaliciousHookCallerMock.sol
+++ b/contracts/mocks/token/ERC7984/ERC7984MaliciousHookCallerMock.sol
@@ -44,7 +44,7 @@ contract ERC7984MaliciousHookCallerMock is HandleAccessManager, ZamaEthereumConf
         euint64 encryptedAmount = FHE.asEuint64(amount);
         FHE.allowThis(encryptedAmount);
         FHE.allowTransient(encryptedAmount, hookModule);
-        IERC7984HookModule(hookModule).preTransfer(from, to, encryptedAmount);
+        IERC7984HookModule(hookModule).preTransfer(msg.sender, from, to, encryptedAmount);
     }
 
     /// @dev Calls `hookModule.postTransfer` with this contract as the token (msg.sender).
@@ -52,7 +52,7 @@ contract ERC7984MaliciousHookCallerMock is HandleAccessManager, ZamaEthereumConf
         euint64 encryptedAmount = FHE.asEuint64(amount);
         FHE.allowThis(encryptedAmount);
         FHE.allowTransient(encryptedAmount, hookModule);
-        IERC7984HookModule(hookModule).postTransfer(from, to, encryptedAmount);
+        IERC7984HookModule(hookModule).postTransfer(msg.sender, from, to, encryptedAmount);
     }
 
     /// @dev Silently returns without reverting and without granting any handle allowance.

--- a/contracts/mocks/token/ERC7984/utils/ERC7984HolderCapHookModuleMock.sol
+++ b/contracts/mocks/token/ERC7984/utils/ERC7984HolderCapHookModuleMock.sol
@@ -12,8 +12,14 @@ contract ERC7984HolderCapHookModuleMock is ERC7984HolderCapHookModule, ZamaEther
         _owner = owner_;
     }
 
-    function _postTransfer(address token, address from, address to, euint64 encryptedAmount) internal override {
-        super._postTransfer(token, from, to, encryptedAmount);
+    function _postTransfer(
+        address token,
+        address operator,
+        address from,
+        address to,
+        euint64 encryptedAmount
+    ) internal override {
+        super._postTransfer(token, operator, from, to, encryptedAmount);
 
         FHE.allow(holderCount(token), _owner);
     }

--- a/contracts/mocks/token/ERC7984/utils/ERC7984HookModuleMock.sol
+++ b/contracts/mocks/token/ERC7984/utils/ERC7984HookModuleMock.sol
@@ -10,8 +10,8 @@ import {ERC7984HookModule} from "../../../../token/ERC7984/utils/ERC7984HookModu
 contract ERC7984HookModuleMock is ERC7984HookModule, ZamaEthereumConfig {
     bool public isCompliant = true;
 
-    event PostTransfer();
-    event PreTransfer();
+    event PostTransfer(address operator, address from, address to);
+    event PreTransfer(address operator, address from, address to);
 
     event OnInstall(bytes initData);
 
@@ -24,7 +24,13 @@ contract ERC7984HookModuleMock is ERC7984HookModule, ZamaEthereumConfig {
         isCompliant = isCompliant_;
     }
 
-    function _preTransfer(address token, address from, address, euint64) internal override returns (ebool) {
+    function _preTransfer(
+        address token,
+        address operator,
+        address from,
+        address to,
+        euint64
+    ) internal override returns (ebool) {
         euint64 fromBalance = IERC7984(token).confidentialBalanceOf(from);
 
         if (FHE.isInitialized(fromBalance)) {
@@ -32,12 +38,18 @@ contract ERC7984HookModuleMock is ERC7984HookModule, ZamaEthereumConfig {
             assert(FHE.isAllowed(fromBalance, address(this)));
         }
 
-        emit PreTransfer();
+        emit PreTransfer(operator, from, to);
         return FHE.asEbool(isCompliant);
     }
 
-    function _postTransfer(address token, address from, address to, euint64 amount) internal override {
-        emit PostTransfer();
-        super._postTransfer(token, from, to, amount);
+    function _postTransfer(
+        address token,
+        address operator,
+        address from,
+        address to,
+        euint64 amount
+    ) internal override {
+        emit PostTransfer(operator, from, to);
+        super._postTransfer(token, operator, from, to, amount);
     }
 }

--- a/contracts/token/ERC7984/extensions/ERC7984Hooked.sol
+++ b/contracts/token/ERC7984/extensions/ERC7984Hooked.sol
@@ -115,6 +115,10 @@ abstract contract ERC7984Hooked is ERC7984, HandleAccessManager, IERC7984Hooked 
      * Modified to run pre and post transfer hooks. Zero tokens are transferred if a module does not approve
      * the transfer. Updates with `bypassRestrictions` set to true skip pre-transfer hook gating but still run
      * post-transfer hooks.
+     *
+     * Hooks receive `msg.sender` as the transfer's operator. It is equal to `from` for direct transfers, and
+     * differs from it when the transfer is initiated by an approved operator or by a contract calling into the
+     * token (e.g. mints, burns and forced transfers driven by another contract).
      */
     function _update(
         address from,
@@ -122,15 +126,17 @@ abstract contract ERC7984Hooked is ERC7984, HandleAccessManager, IERC7984Hooked 
         euint64 encryptedAmount,
         bool bypassRestrictions
     ) internal virtual override returns (euint64 transferred) {
+        address operator = msg.sender;
         euint64 amountToTransfer = bypassRestrictions
             ? encryptedAmount
-            : FHE.select(_runPreTransferHooks(from, to, encryptedAmount), encryptedAmount, FHE.asEuint64(0));
+            : FHE.select(_runPreTransferHooks(operator, from, to, encryptedAmount), encryptedAmount, FHE.asEuint64(0));
         transferred = super._update(from, to, amountToTransfer, bypassRestrictions);
-        _runPostTransferHooks(from, to, transferred);
+        _runPostTransferHooks(operator, from, to, transferred);
     }
 
     /// @dev Runs the pre-transfer hooks for all modules.
     function _runPreTransferHooks(
+        address operator,
         address from,
         address to,
         euint64 encryptedAmount
@@ -140,17 +146,25 @@ abstract contract ERC7984Hooked is ERC7984, HandleAccessManager, IERC7984Hooked 
         compliant = FHE.asEbool(true);
         for (uint256 i = 0; i < modulesLength; ++i) {
             if (FHE.isInitialized(encryptedAmount)) FHE.allowTransient(encryptedAmount, modules_[i]);
-            compliant = FHE.and(compliant, IERC7984HookModule(modules_[i]).preTransfer(from, to, encryptedAmount));
+            compliant = FHE.and(
+                compliant,
+                IERC7984HookModule(modules_[i]).preTransfer(operator, from, to, encryptedAmount)
+            );
         }
     }
 
     /// @dev Runs the post-transfer hooks for all modules.
-    function _runPostTransferHooks(address from, address to, euint64 encryptedAmount) internal virtual {
+    function _runPostTransferHooks(
+        address operator,
+        address from,
+        address to,
+        euint64 encryptedAmount
+    ) internal virtual {
         address[] memory modules_ = modules(0, type(uint256).max);
         uint256 modulesLength = modules_.length;
         for (uint256 i = 0; i < modulesLength; i++) {
             if (FHE.isInitialized(encryptedAmount)) FHE.allowTransient(encryptedAmount, modules_[i]);
-            IERC7984HookModule(modules_[i]).postTransfer(from, to, encryptedAmount);
+            IERC7984HookModule(modules_[i]).postTransfer(operator, from, to, encryptedAmount);
         }
     }
 

--- a/contracts/token/ERC7984/utils/ERC7984BalanceCapHookModule.sol
+++ b/contracts/token/ERC7984/utils/ERC7984BalanceCapHookModule.sol
@@ -56,12 +56,13 @@ contract ERC7984BalanceCapHookModule is ERC7984HookModule {
     /// @inheritdoc ERC7984HookModule
     function _preTransfer(
         address token,
+        address operator,
         address from,
         address to,
         euint64 encryptedAmount
     ) internal override returns (ebool result) {
         // super call
-        result = super._preTransfer(token, from, to, encryptedAmount);
+        result = super._preTransfer(token, operator, from, to, encryptedAmount);
 
         // in non trivial cases, check (and document) compliance.
         if (to != address(0) && to != from && FHE.isInitialized(maxBalance(token))) {

--- a/contracts/token/ERC7984/utils/ERC7984HolderCapHookModule.sol
+++ b/contracts/token/ERC7984/utils/ERC7984HolderCapHookModule.sol
@@ -60,11 +60,12 @@ contract ERC7984HolderCapHookModule is ERC7984HookModule {
     /// @inheritdoc ERC7984HookModule
     function _preTransfer(
         address token,
+        address operator,
         address from,
         address to,
         euint64 encryptedAmount
     ) internal override returns (ebool result) {
-        result = super._preTransfer(token, from, to, encryptedAmount);
+        result = super._preTransfer(token, operator, from, to, encryptedAmount);
 
         // in non trivial cases, check compliance.
         if (to != address(0) && to != from) {
@@ -92,8 +93,14 @@ contract ERC7984HolderCapHookModule is ERC7984HookModule {
     }
 
     /// @inheritdoc ERC7984HookModule
-    function _postTransfer(address token, address from, address to, euint64 encryptedAmount) internal virtual override {
-        super._postTransfer(token, from, to, encryptedAmount);
+    function _postTransfer(
+        address token,
+        address operator,
+        address from,
+        address to,
+        euint64 encryptedAmount
+    ) internal virtual override {
+        super._postTransfer(token, operator, from, to, encryptedAmount);
 
         if (from == to) return;
 

--- a/contracts/token/ERC7984/utils/ERC7984HookModule.sol
+++ b/contracts/token/ERC7984/utils/ERC7984HookModule.sol
@@ -26,23 +26,28 @@ abstract contract ERC7984HookModule is IERC7984HookModule, ERC165 {
     }
 
     /// @inheritdoc IERC7984HookModule
-    function preTransfer(address from, address to, euint64 encryptedAmount) public virtual returns (ebool) {
+    function preTransfer(
+        address operator,
+        address from,
+        address to,
+        euint64 encryptedAmount
+    ) public virtual returns (ebool) {
         require(
             FHE.isAllowed(encryptedAmount, msg.sender),
             ERC7984HookModuleUnauthorizedUseOfEncryptedAmount(encryptedAmount, msg.sender)
         );
-        ebool compliant = _preTransfer(msg.sender, from, to, encryptedAmount);
+        ebool compliant = _preTransfer(msg.sender, operator, from, to, encryptedAmount);
         FHE.allowTransient(compliant, msg.sender);
         return compliant;
     }
 
     /// @inheritdoc IERC7984HookModule
-    function postTransfer(address from, address to, euint64 encryptedAmount) public virtual {
+    function postTransfer(address operator, address from, address to, euint64 encryptedAmount) public virtual {
         require(
             FHE.isAllowed(encryptedAmount, msg.sender),
             ERC7984HookModuleUnauthorizedUseOfEncryptedAmount(encryptedAmount, msg.sender)
         );
-        _postTransfer(msg.sender, from, to, encryptedAmount);
+        _postTransfer(msg.sender, operator, from, to, encryptedAmount);
     }
 
     /// @inheritdoc IERC7984HookModule
@@ -75,9 +80,12 @@ abstract contract ERC7984HookModule is IERC7984HookModule, ERC165 {
      * for `encryptedAmount`. If additional handle access is needed from the token, call {_getTokenHandleAllowance}.
      *
      * NOTE: ACL allowance on `encryptedAmount` is already checked for `msg.sender` in {preTransfer}.
+     *
+     * IMPORTANT: `operator` is reported by the calling token and is only as trustworthy as that token.
      */
     function _preTransfer(
         address /* token */,
+        address /* operator */,
         address /* from */,
         address /* to */,
         euint64 /* encryptedAmount */
@@ -90,9 +98,12 @@ abstract contract ERC7984HookModule is IERC7984HookModule, ERC165 {
      * for `encryptedAmount`. If additional handle access is needed from the token, call {_getTokenHandleAllowance}.
      *
      * NOTE: ACL allowance on `encryptedAmount` is already checked for `msg.sender` in {postTransfer}.
+     *
+     * IMPORTANT: `operator` is reported by the calling token and is only as trustworthy as that token.
      */
     function _postTransfer(
         address /*token*/,
+        address /*operator*/,
         address /*from*/,
         address /*to*/,
         euint64 /*encryptedAmount*/

--- a/test/helpers/interface.ts
+++ b/test/helpers/interface.ts
@@ -52,8 +52,8 @@ export const SIGNATURES = {
     'recoverAddress(address,address)',
   ],
   ERC7984HookModule: [
-    'preTransfer(address,address,bytes32)',
-    'postTransfer(address,address,bytes32)',
+    'preTransfer(address,address,address,bytes32)',
+    'postTransfer(address,address,address,bytes32)',
     'onInstall(bytes)',
   ],
   ERC7984Hooked: [

--- a/test/token/ERC7984/extensions/ERC7984Hooked.test.ts
+++ b/test/token/ERC7984/extensions/ERC7984Hooked.test.ts
@@ -139,15 +139,29 @@ describe('ERC7984Hooked', function () {
     });
 
     it('should call pre-transfer hooks', async function () {
-      await expect(
-        this.token.connect(this.holder)['confidentialTransfer(address,uint64)'](this.recipient, 100n),
-      ).to.emit(this.hookModule, 'PreTransfer');
+      await expect(this.token.connect(this.holder)['confidentialTransfer(address,uint64)'](this.recipient, 100n))
+        .to.emit(this.hookModule, 'PreTransfer')
+        .withArgs(this.holder, this.holder, this.recipient);
     });
 
     it('should call post-transfer hooks', async function () {
-      await expect(
-        this.token.connect(this.holder)['confidentialTransfer(address,uint64)'](this.recipient, 100n),
-      ).to.emit(this.hookModule, 'PostTransfer');
+      await expect(this.token.connect(this.holder)['confidentialTransfer(address,uint64)'](this.recipient, 100n))
+        .to.emit(this.hookModule, 'PostTransfer')
+        .withArgs(this.holder, this.holder, this.recipient);
+    });
+
+    it('should pass the operator to the hooks on an operator-initiated transfer', async function () {
+      await this.token.connect(this.holder).setOperator(this.anyone, 2n ** 48n - 1n);
+
+      const creation = await (await this.token.connect(this.anyone).createEncryptedAmount(100)).wait();
+      const handle = creation.logs.filter((log: any) => log.fragment?.name === 'EncryptedAmountCreated')[0].args[0];
+
+      const tx = this.token
+        .connect(this.anyone)
+        ['confidentialTransferFrom(address,address,bytes32)'](this.holder, this.recipient, handle);
+
+      await expect(tx).to.emit(this.hookModule, 'PreTransfer').withArgs(this.anyone, this.holder, this.recipient);
+      await expect(tx).to.emit(this.hookModule, 'PostTransfer').withArgs(this.anyone, this.holder, this.recipient);
     });
 
     for (const approve of [true, false]) {

--- a/test/token/ERC7984/utils/ERC7984HookModule.test.ts
+++ b/test/token/ERC7984/utils/ERC7984HookModule.test.ts
@@ -34,7 +34,12 @@ describe('ERC7984HookModule', function () {
         .encrypt();
 
       await expect(
-        this.hookModule.preTransfer(this.holder.address, this.recipient.address, encryptedAmount.handles[0]),
+        this.hookModule.preTransfer(
+          this.holder.address,
+          this.holder.address,
+          this.recipient.address,
+          encryptedAmount.handles[0],
+        ),
       ).to.be.revertedWithCustomError(this.hookModule, 'ERC7984HookModuleUnauthorizedUseOfEncryptedAmount');
     });
   });
@@ -46,7 +51,12 @@ describe('ERC7984HookModule', function () {
         .add64(100)
         .encrypt();
       await expect(
-        this.hookModule.postTransfer(this.holder.address, this.recipient.address, encryptedAmount.handles[0]),
+        this.hookModule.postTransfer(
+          this.holder.address,
+          this.holder.address,
+          this.recipient.address,
+          encryptedAmount.handles[0],
+        ),
       ).to.be.revertedWithCustomError(this.hookModule, 'ERC7984HookModuleUnauthorizedUseOfEncryptedAmount');
     });
   });


### PR DESCRIPTION
`ERC7984Hooked._update` now forwards `msg.sender` as the transfer's operator to
`_runPreTransferHooks` and `_runPostTransferHooks`, which pass it on to the
installed modules. `IERC7984HookModule.preTransfer`/`postTransfer` gain a leading
`operator` argument, and `ERC7984HookModule._preTransfer`/`_postTransfer` receive
it after `token`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transfer hooks now receive the address that initiated each transfer.
  * Hook events include the operator, sender, and recipient, improving transfer visibility.
  * Operator-initiated transfers are now covered in hook behavior and validation.

* **Tests**
  * Added coverage confirming operator details are correctly passed through pre- and post-transfer hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->